### PR TITLE
Improvements to error handling

### DIFF
--- a/bin/npg_publish_illumina_run.pl
+++ b/bin/npg_publish_illumina_run.pl
@@ -8,8 +8,7 @@ use lib (-d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib");
 use Data::Dump qw[pp];
 use Getopt::Long;
 use List::AllUtils qw[none];
-use Log::Log4perl;
-use Log::Log4perl::Level;
+use Log::Log4perl qw[:levels];
 use Pod::Usage;
 
 use WTSI::DNAP::Warehouse::Schema;
@@ -88,15 +87,11 @@ else {
   if ($verbose and not $debug) {
     Log::Log4perl::init(\$verbose_config);
   }
-  elsif ($debug) {
-    Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
-                              level  => $DEBUG,
-                              utf8   => 1})
-  }
   else {
+    my $level = $debug ? $DEBUG : $WARN;
     Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
-                              level  => $ERROR,
-                              utf8   => 1})
+                              level  => $level,
+                              utf8   => 1});
   }
 }
 


### PR DESCRIPTION
Failure to parse a JSON read count cache file is captured and added to
the error count. It is no longer immediately fatal, but will cause a
non-zero exit of the loading script.

Failure to make an MD5 cache file is reduced from a fatal error to a
warning.

Warnings now come through the logger, rather than raw carping, so they
gain a WARN tag.

Default log level has been lowered from ERROR to WARN.