### PR TITLE
BioNano: Command line script for publication; refactor publisher class

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -6,9 +6,9 @@ use warnings;
 # directory is added because the Test::Class tests are there.
 use lib qw(lib t/lib);
 
-use WTSI::DNAP::Utilities::Build;
+use Build;
 
-my $build = WTSI::DNAP::Utilities::Build->new
+my $build = Build->new
   (module_name        => 'npg_irods',
    dist_author        => 'NPG <npg@sanger.ac.uk>',
    dist_abstract      => 'NPG iRODS data/metadata loading and update tools',

--- a/Build.pm
+++ b/Build.pm
@@ -1,0 +1,21 @@
+
+package Build;
+
+use strict;
+use warnings;
+
+use base 'WTSI::DNAP::Utilities::Build';
+
+#
+# Prepare environment for tests
+#
+sub ACTION_test {
+  my ($self) = @_;
+  # Ensure that the tests can see the Perl scripts
+  {
+      local $ENV{PATH} = "./bin:$ENV{PATH}";
+      $self->SUPER::ACTION_test;
+  }
+}
+
+1;

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,10 +1,12 @@
 .travis.yml
+bin/npg_publish_bionano_run.pl
 bin/npg_publish_illumina_logs.pl
 bin/npg_publish_illumina_run.pl
 bin/npg_update_ebi_metadata.pl
 bin/npg_update_hts_metadata.pl
 bin/samgen.pl
 Build.PL
+Build.pm
 Changes
 etc/log4perl_tests.conf
 lib/WTSI/DNAP/Utilities/Params.pm
@@ -43,8 +45,8 @@ lib/WTSI/NPG/HTS/Seqchksum.pm
 lib/WTSI/NPG/HTS/Types.pm
 lib/WTSI/NPG/OM/BioNano/Annotator.pm
 lib/WTSI/NPG/OM/BioNano/BnxFile.pm
-lib/WTSI/NPG/OM/BioNano/Publisher.pm
 lib/WTSI/NPG/OM/BioNano/ResultSet.pm
+lib/WTSI/NPG/OM/BioNano/RunPublisher.pm
 lib/WTSI/NPG/OM/Metadata.pm
 LICENSE
 MANIFEST			This list of files
@@ -56,8 +58,8 @@ t/aln_data_object.t
 t/anc_data_object.t
 t/annotator.t
 t/bionano_bnx_file.t
-t/bionano_publisher.t
 t/bionano_result_set.t
+t/bionano_run_publisher.t
 t/compile_scripts.t
 t/critic.t
 t/data/aln_data_object/1000_1#1.cram
@@ -7542,8 +7544,8 @@ t/lib/WTSI/NPG/HTS/PublisherTest.pm
 t/lib/WTSI/NPG/HTS/SeqchksumTest.pm
 t/lib/WTSI/NPG/HTS/Test.pm
 t/lib/WTSI/NPG/OM/BioNano/BnxFileTest.pm
-t/lib/WTSI/NPG/OM/BioNano/PublisherTest.pm
 t/lib/WTSI/NPG/OM/BioNano/ResultSetTest.pm
+t/lib/WTSI/NPG/OM/BioNano/RunPublisherTest.pm
 t/log_publisher.t
 t/datasub_meta_updater.t
 t/illumina_meta_updater.t

--- a/bin/npg_publish_bionano_run.pl
+++ b/bin/npg_publish_bionano_run.pl
@@ -1,0 +1,193 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use FindBin qw[$Bin];
+use lib (-d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib");
+
+use Cwd qw(cwd abs_path);
+use DateTime;
+use Getopt::Long;
+use Log::Log4perl qw(:levels);
+use Pod::Usage;
+use Try::Tiny;
+use WTSI::DNAP::Utilities::Collector;
+use WTSI::DNAP::Utilities::ConfigureLogger qw(log_init);
+use WTSI::NPG::OM::BioNano::RunPublisher;
+
+our $VERSION = '';
+our $BIONANO_REGEX = qr{^\S+_\d{4}-\d{2}-\d{2}_\d{2}_\d{2}$}msx;
+our $DEFAULT_DAYS = 7;
+
+if (! caller ) {
+    my $result = run();
+    if ($result == 0) { exit 1; }
+    else { exit 0; }
+}
+sub run {
+
+    my $days;
+    my $days_ago;
+    my $debug;
+    my $log4perl_config;
+    my $collection;
+    my $runfolder_path;
+    my $search_dir;
+    my $verbose;
+
+    GetOptions(
+        'days=i'                          => \$days,
+        'days-ago|days_ago=i'             => \$days_ago,
+        'debug'                           => \$debug,
+        'collection=s'                    => \$collection,
+        'help'                            => sub {
+            pod2usage(-verbose => 2, -exitval => 0) },
+        'logconf=s'                       => \$log4perl_config,
+        'runfolder-path|runfolder_path=s' => \$runfolder_path,
+        'search-dir|search_dir=s'         => \$search_dir,
+        'verbose'                         => \$verbose
+    );
+
+    if (defined $search_dir && defined $runfolder_path) {
+        my $msg = "Cannot supply both --search_dir and --runfolder_path\n";
+        pod2usage(-msg     => $msg,
+                  -exitval => 2);
+    }
+    if (! defined $collection) {
+        pod2usage(-msg     => "A --collection argument is required\n",
+                  -exitval => 2);
+    }
+    $days           ||= $DEFAULT_DAYS;
+    $days_ago       ||= 0;
+
+    my @log_levels;
+    if ($debug) { push @log_levels, $DEBUG; }
+    if ($verbose) { push @log_levels, $INFO; }
+    log_init(config => $log4perl_config,
+             levels => \@log_levels);
+    my $log = Log::Log4perl->get_logger('main');
+
+    # find and publish directories
+    my @dirs;
+    if (defined $runfolder_path) {
+        push @dirs, $runfolder_path;
+        $log->info(q[Publishing runfolder path '], $runfolder_path,
+                   q[' to '], $collection, q[']);
+    } else {
+        $search_dir ||= cwd();
+        $search_dir = abs_path($search_dir);
+        my $now = DateTime->now;
+        my $end;
+        if ($days_ago > 0) {
+            $end = DateTime->from_epoch
+                (epoch => $now->epoch)->subtract(days => $days_ago);
+        } else {
+            $end = $now;
+        }
+        my $begin = DateTime->from_epoch
+            (epoch => $end->epoch)->subtract(days => $days);
+        $log->info(q[Publishing from '], $search_dir, q[' to '],
+                   $collection, q[' BioNano results finished between ],
+                   $begin->iso8601, q[ and ], $end->iso8601);
+        my $collector = WTSI::DNAP::Utilities::Collector->new(
+            root  => $search_dir,
+            depth => 2,
+            regex => $BIONANO_REGEX,
+        );
+        @dirs = $collector->collect_dirs_modified_between($begin->epoch,
+                                                          $end->epoch);
+    }
+    my $total = scalar @dirs;
+    my $num_published = 0;
+    my $errors = 0;
+    $log->debug(q[Ready to publish ], $total, q[ BioNano runfolder(s) to '],
+                $collection, q[']);
+    foreach my $dir (@dirs) {
+        try {
+            my $publisher = WTSI::NPG::OM::BioNano::RunPublisher->new(
+                directory => $dir,
+            );
+            my $dest_collection = $publisher->publish($collection);
+            $num_published++;
+            $log->info(q[Published BioNano run directory '], $dir,
+                       q[' to iRODS collection '], $dest_collection,
+                       q[': ], $num_published, q[ of ], $total);
+        } catch {
+            $log->error("Error publishing '$dir': ", $_);
+            $errors++;
+        };
+    }
+    my $status = 1;
+    if ($errors == 0) {
+        $log->info(q[Finished successfully: Published ],
+                   $total, q[ BioNano run(s)]);
+    } else {
+        $log->error(q[Finished with errors: Attempted to publish ], $total,
+                    q[ BioNano run(s); ], $num_published, q[ succeeded, ],
+                    $errors, q[ failed]);
+        $status = 0;
+    }
+    return $status;
+}
+
+__END__
+
+=head1 NAME
+
+npg_publish_bionano_run
+
+=head1 SYNOPSIS
+
+Options:
+
+  --days-ago
+  --days_ago        The number of days ago that the publication window
+                    ends. Optional, defaults to zero (the current day).
+                    Has no effect if the --runfolder_path option is used.
+  --days            The number of days in the publication window, ending
+                    at the day given by the --days-ago argument. Any sample
+                    data modified during this period will be considered
+                    for publication. Optional, defaults to 7 days.
+                    Has no effect if the --runfolder_path option is used.
+  --collection      The data destination root collection in iRODS.
+  --help            Display help.
+  --logconf         A log4perl configuration file. Optional.
+  --runfolder-path
+  --runfolder_path  The instrument runfolder path to load. Incompatible
+                    with --search_dir. Optional. If neither this option
+                    nor --search_dir is given, the default value of
+                    --search_dir is used.
+  --search-dir
+  --search_dir      The root directory to search for BioNano data. The
+                    --days_ago and --days options determine a time window
+                    for runfolders to be published. Incompatible with
+                    --runfolder_path. Optional, defaults to current working
+                    directory.
+  --verbose         Print messages while processing. Optional.
+
+=head1 DESCRIPTION
+
+This script loads data and metadata for a unit BioNano runfolder into
+iRODS. The 'unit' runfolder contains results for a run with one sample on
+one flowcell. Typically, multiple unit runfolders are merged together for
+downstream analysis.
+
+=head1 AUTHOR
+
+Iain Bancarz <ib5@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2016 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/lib/WTSI/NPG/OM/BioNano/RunPublisher.pm
+++ b/lib/WTSI/NPG/OM/BioNano/RunPublisher.pm
@@ -1,4 +1,4 @@
-package WTSI::NPG::OM::BioNano::Publisher;
+package WTSI::NPG::OM::BioNano::RunPublisher;
 
 use Moose;
 use namespace::autoclean;
@@ -27,6 +27,13 @@ with qw[WTSI::DNAP::Utilities::Loggable
         WTSI::NPG::Accountable
         WTSI::NPG::OM::BioNano::Annotator];
 
+has 'directory' =>
+  (is       => 'ro',
+   isa      => 'Str',
+   required => 1,
+   documentation => 'Path of a BioNano runfolder to be published'
+);
+
 has 'irods' =>
   (is       => 'ro',
    isa      => 'WTSI::NPG::iRODS',
@@ -38,7 +45,11 @@ has 'irods' =>
 has 'resultset' =>
   (is       => 'ro',
    isa      => 'WTSI::NPG::OM::BioNano::ResultSet',
-   required => 1);
+   init_arg => undef,
+   lazy     => 1,
+   builder  => '_build_resultset',
+   documentation => 'Object containing results from a BioNano runfolder'
+);
 
 has 'uuid' =>
   (is       => 'ro',
@@ -161,8 +172,16 @@ sub _apply_bnx_file_metadata {
     return $bnx_ipath;
 }
 
+sub _build_resultset {
+    my ($self,) = @_;
+    my $resultset = WTSI::NPG::OM::BioNano::ResultSet->new(
+        directory => $self->directory
+    );
+    return $resultset;
+}
+
 sub _build_uuid {
-    my (@self) = @_;
+    my ($self,) = @_;
     my $uuid_bin;
     my $uuid_str;
     UUID::generate($uuid_bin);
@@ -181,7 +200,7 @@ __END__
 
 =head1 NAME
 
-WTSI::NPG::OM::BioNano::Publisher - An iRODS data publisher
+WTSI::NPG::OM::BioNano::RunPublisher - An iRODS data publisher
 for results from the BioNano optical mapping system.
 
 =head1 SYNOPSIS
@@ -189,7 +208,7 @@ for results from the BioNano optical mapping system.
   my $resultset = WTSI::NPG::OM::BioNano::ResultSet->new
     (directory => $dir);
 
-  my $publisher = WTSI::NPG::OM::BioNano::Publisher->new
+  my $publisher = WTSI::NPG::OM::BioNano::RunPublisher->new
     (irods            => $irods_handle,
      accountee_uid    => $accountee_uid,
      affiliation_uri  => $affiliation_uri,

--- a/t/bionano_publisher.t
+++ b/t/bionano_publisher.t
@@ -1,7 +1,0 @@
-
-use strict;
-use warnings;
-
-use WTSI::NPG::OM::BioNano::PublisherTest;
-
-WTSI::NPG::OM::BioNano::PublisherTest->runtests;

--- a/t/bionano_run_publisher.t
+++ b/t/bionano_run_publisher.t
@@ -1,0 +1,7 @@
+
+use strict;
+use warnings;
+
+use WTSI::NPG::OM::BioNano::RunPublisherTest;
+
+WTSI::NPG::OM::BioNano::RunPublisherTest->runtests;

--- a/t/lib/WTSI/NPG/OM/BioNano/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/OM/BioNano/RunPublisherTest.pm
@@ -1,4 +1,4 @@
-package WTSI::NPG::OM::BioNano::PublisherTest;
+package WTSI::NPG::OM::BioNano::RunPublisherTest;
 
 use strict;
 use warnings;
@@ -7,7 +7,7 @@ use URI;
 
 use base qw[WTSI::NPG::HTS::Test]; # FIXME better path for shared base
 
-use Test::More tests => 7;
+use Test::More tests => 17;
 use Test::Exception;
 
 use English qw[-no_match_vars];
@@ -16,14 +16,14 @@ use File::Temp qw[tempdir];
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
 
-BEGIN { use_ok('WTSI::NPG::OM::BioNano::Publisher'); }
+BEGIN { use_ok('WTSI::NPG::OM::BioNano::RunPublisher'); }
 
 use WTSI::NPG::iRODS;
-use WTSI::NPG::OM::BioNano::Publisher;
-use WTSI::NPG::OM::BioNano::ResultSet;
+use WTSI::NPG::OM::BioNano::RunPublisher;
 
 my $data_path = './t/data/bionano/';
 my $runfolder_name = 'sample_barcode_01234_2016-10-04_09_00';
+my $tmp_data;
 my $test_run_path;
 my $irods_tmp_coll;
 my $pid = $$;
@@ -34,12 +34,12 @@ sub make_fixture : Test(setup) {
     # set up iRODS test collection
     my $irods = WTSI::NPG::iRODS->new;
     my $irods_cwd = $irods->working_collection;
-    $irods_tmp_coll = catfile($irods_cwd, "BioNanoPublisherTest.$pid");
+    $irods_tmp_coll = catfile($irods_cwd, "BioNanoRunPublisherTest.$pid");
     $irods->add_collection($irods_tmp_coll);
     # create a temporary directory for test data
     # workaround for the space in BioNano's "Detect Molecules" directory,
     # because Build.PL does not work well with spaces in filenames
-    my $tmp_data = tempdir('temp_bionano_data_XXXXXX', CLEANUP => 1);
+    $tmp_data = tempdir('temp_bionano_data_XXXXXX', CLEANUP => 1);
     my $run_path = $data_path.$runfolder_name;
     system("cp -R $run_path $tmp_data") && $log->logcroak(
         q[Failed to copy '], $run_path, q[' to '], $tmp_data, q[']);
@@ -58,29 +58,22 @@ sub teardown : Test(teardown) {
 
 sub publish : Test(2) {
     my $irods = WTSI::NPG::iRODS->new();
-    my $resultset = WTSI::NPG::OM::BioNano::ResultSet->new(
-        directory => $test_run_path,
-    );
     my $publication_time = DateTime->now;
-    my $publisher = WTSI::NPG::OM::BioNano::Publisher->new(
-        resultset => $resultset,
+    my $publisher = WTSI::NPG::OM::BioNano::RunPublisher->new(
+        directory => $test_run_path,
         publication_time => $publication_time,
     );
-    ok($publisher, "BioNano Publisher object created");
+    ok($publisher, "BioNano RunPublisher object created");
 
     my $run_collection;
     lives_ok(
         sub { $run_collection = $publisher->publish($irods_tmp_coll); },
         'ResultSet published OK'
     );
-
 }
 
 sub metadata : Test(4) {
     my $irods = WTSI::NPG::iRODS->new();
-    my $resultset = WTSI::NPG::OM::BioNano::ResultSet->new(
-        directory => $test_run_path,
-    );
     my $publication_time = DateTime->new(
         year       => 2016,
         month      => 1,
@@ -90,8 +83,8 @@ sub metadata : Test(4) {
     );
     my $user_name = getpwuid $REAL_USER_ID;
     my $affiliation_uri = URI->new('http://www.sanger.ac.uk');
-    my $publisher = WTSI::NPG::OM::BioNano::Publisher->new(
-        resultset => $resultset
+    my $publisher = WTSI::NPG::OM::BioNano::RunPublisher->new(
+        directory => $test_run_path
     );
     my $bionano_coll = $publisher->publish($irods_tmp_coll,
                                            $publication_time);
@@ -156,6 +149,52 @@ sub metadata : Test(4) {
 
     is_deeply(\@file_meta, \@expected_meta,
               'BNX file metadata matches expected values');
+}
+
+sub script : Test(10) {
+
+    my $irods = WTSI::NPG::iRODS->new();
+
+    system("find $test_run_path -exec touch {} +") && $log->logcroak(
+        "Failed to recursively update access time for $test_run_path"
+    );
+
+    my $script = "npg_publish_bionano_run.pl";
+
+    my $cmd = "$script --collection $irods_tmp_coll --search_dir $tmp_data";
+
+    ok(system($cmd)==0, "Publish script run successfully with search dir");
+
+    my $expected_coll = $irods_tmp_coll."/d5/0f/b6/".$runfolder_name;
+    ok($irods->is_collection($expected_coll),
+       "Script publishes to expected iRODS collection");
+
+    my $expected_bnx = $expected_coll."/Detect Molecules/Molecules.bnx";
+    ok($irods->is_object($expected_bnx),
+       "Script publishes expected filtered BNX file");
+
+    $irods->remove_collection($expected_coll);
+
+    $cmd = "$script --collection $irods_tmp_coll --search_dir $tmp_data ".
+        "--runfolder_path $test_run_path 2> /dev/null";
+    ok(system($cmd)!=0, "Publish script fails with incompatible arguments");
+    ok(! $irods->is_collection($expected_coll),
+       "No iRODS collection published by failed script");
+
+    $cmd = "$script --collection $irods_tmp_coll --runfolder_path ".
+        "$tmp_data/foo/bar 2> /dev/null";
+    ok(system($cmd)!=0, "Publish script has non-zero exit status for ".
+           "nonexistent input");
+    ok(! $irods->is_collection($expected_coll),
+       "No iRODS collection published by failed script");
+
+    $cmd = "$script --collection $irods_tmp_coll ".
+        "--runfolder_path $test_run_path";
+    ok(system($cmd)==0, "Publish script run successfully with runfolder");
+    ok($irods->is_collection($expected_coll),
+       "Script publishes to expected iRODS collection");
+    ok($irods->is_object($expected_bnx),
+       "Script publishes expected filtered BNX file");
 }
 
 

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -19,7 +19,7 @@ private_name_regex = _(?!build_)\w+
 [-InputOutput::RequireBracedFileHandleWithPrint]
 
 [ValuesAndExpressions::ProhibitMagicNumbers]
-allowed_values = -1 0 1 2 4 8 16 32 64 128 256 512 1024 4096
+allowed_values = -1 0 1 2 4 7 8 16 32 64 128 256 512 1024 4096
 
 [-Variables::ProhibitPunctuationVars]
 


### PR DESCRIPTION
- Script to publish BioNano:
    - Can publish a single runfolder path
    - Alternatively, can search a directory for all runfolders within a given time window
    - Catches publication errors, exits with non-zero status if any are found
- Build.pm added, to ensure Perl tests can execute the command line scripts
- Renamed BioNano::Publisher as RunPublisher, for consistency with HTS classes
- Refactor RunPublisher to encapsulate a ResultSet object