### PR TITLE
Avoid testcover on Travis to keep build time down.

### DIFF
--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -8,10 +8,4 @@ export WTSI_NPG_iRODS_Test_IRODS_ENVIRONMENT_FILE=$HOME/.irods/irods_environment
 
 perl Build.PL
 ./Build clean
-./Build testcover
-
-if [ $? -ne 0 ]; then
-    echo ===============================================================================
-    cat tests.log
-    echo ===============================================================================
-fi
+./Build test


### PR DESCRIPTION
Avoid testcover on Travis to keep build time down.
Removed log printing commands which could never be run.