### PR TITLE
Build script fixes and enhancements

### DIFF
--- a/scripts/minion/install_baton.sh
+++ b/scripts/minion/install_baton.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 
 set -x
 
-PREFIX=${PREFIX:=/usr/local/minion}
+PREFIX=${PREFIX:=/usr/local/npg}
 
 TMPDIR=$PWD/
 TMP=$(mktemp -d ${TMPDIR:-/tmp/}$(basename -- "$0").XXXXXXXXXX)
@@ -39,9 +39,6 @@ install_baton() {
     make install
     popd
 }
-
-sudo mkdir -p "$PREFIX"
-sudo chown -R ${USER}:${USER} "$PREFIX"
 
 pushd "$TMP"
 download_baton_source

--- a/scripts/minion/install_hdf5.sh
+++ b/scripts/minion/install_hdf5.sh
@@ -31,7 +31,7 @@ install_hdf5() {
     tar xfz hdf5-${HDF5_VERSION}.tar.gz -C "$TMP"
     pushd "$TMP/hdf5-${HDF5_VERSION}"
     ./configure --prefix="$PREFIX"
-    make install
+    make -j 2 install
     popd
 }
 

--- a/scripts/minion/install_jansson.sh
+++ b/scripts/minion/install_jansson.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 
 set -x
 
-PREFIX=${PREFIX:=/usr/local/minion}
+PREFIX=${PREFIX:=/usr/local/npg}
 
 TMPDIR=$PWD/
 TMP=$(mktemp -d ${TMPDIR:-/tmp/}$(basename -- "$0").XXXXXXXXXX)
@@ -35,9 +35,6 @@ install_jansson() {
     ./configure --prefix="$PREFIX"
     make install
 }
-
-sudo mkdir -p "$PREFIX"
-sudo chown -R ${USER}:${USER} "$PREFIX"
 
 pushd "$TMP"
 download_jansson_source

--- a/scripts/minion/install_jq.sh
+++ b/scripts/minion/install_jq.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+set -x
+
+PREFIX=${PREFIX:=/usr/local/npg}
+
+TMPDIR=$PWD/
+TMP=$(mktemp -d ${TMPDIR:-/tmp/}$(basename -- "$0").XXXXXXXXXX)
+
+GITHUB_URL=${GITHUB_URL:-https://github.com}
+GITHUB_USER=${GITHUB_USER:=stedolan}
+JQ_VERSION="1.5"
+JQ_SHA256="c4d2bfec6436341113419debf479d833692cc5cdab7eb0326b5a4d4fbe9f493c"
+
+trap cleanup EXIT INT TERM
+
+cleanup() {
+    rm -rf "$TMP"
+}
+
+download_jq_source() {
+    curl -sSL -O ${GITHUB_URL}/$GITHUB_USER/jq/releases/download/jq-${JQ_VERSION}/jq-${JQ_VERSION}.tar.gz
+}
+
+verify_jq_source() {
+    echo "$JQ_SHA256 *jq-${JQ_VERSION}.tar.gz" | sha256sum -c -
+}
+
+install_jq() {
+    tar xfz jq-${JQ_VERSION}.tar.gz -C "$TMP"
+    pushd "$TMP/jq-${JQ_VERSION}"
+    ./configure --prefix="$PREFIX"
+    make install
+    popd
+}
+
+pushd "$TMP"
+download_jq_source
+verify_jq_source
+install_jq
+popd

--- a/scripts/minion/install_npg_irods.sh
+++ b/scripts/minion/install_npg_irods.sh
@@ -14,7 +14,7 @@ GITHUB_USER=${GITHUB_USER:=wtsi-npg}
 
 PERL_DNAP_UTILITIES_VERSION="0.5.5"
 PERL_IRODS_WRAP_VERSION="2.8.1"
-NPG_IRODS_VERSION="ont-build"
+NPG_IRODS_VERSION="devel"
 
 trap cleanup EXIT INT TERM
 
@@ -32,9 +32,9 @@ install_from_source() {
     pushd "$repo_name"
 
     perl "$build_script.PL"
-    ./"$build_script --install_base $PREFIX" \
+    ./"$build_script" --install_base "$PREFIX" \
       --cpan_client "cpanm --notest -L $PREFIX" installdeps
-    ./"$build_script --install_base $PREFIX" \
+    ./"$build_script" --install_base "$PREFIX" \
       --cpan_client "cpanm --notest -L $PREFIX" install
 
     popd
@@ -44,24 +44,19 @@ install_from_source() {
 sudo apt-get install -y cpanminus liblocal-lib-perl uuid-dev
 sudo apt-get install -y git
 
-sudo mkdir -p "$PREFIX"
-sudo chown -R ${USER}:${USER} "$PREFIX"
-
 PERL_LOCAL_LIB_ROOT="$PREFIX"
 PERL5LIB="$PREFIX"/lib/perl5/
 eval $(perl -Mlocal::lib="$PREFIX")
 
 
 export PERL_MM_USE_DEFAULT=1
-
 # The following is not declared in the CPAN dependency graph
 cpanm --notest -L "$PREFIX" Params::Util
-
 # The following are not declared in our build file dependencies
 cpanm --notest -L "$PREFIX" DateTime
 
 install_from_source perl-dnap-utilities "$PERL_DNAP_UTILITIES_VERSION" Build
 install_from_source perl-irods-wrap "$PERL_IRODS_WRAP_VERSION" Build
 
-GITHUB_USER=keithj
+export HDF5_PATH="$PREFIX"
 install_from_source npg_irods "$NPG_IRODS_VERSION" BuildONT

--- a/scripts/minion/install_tears.sh
+++ b/scripts/minion/install_tears.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 
 set -x
 
-PREFIX=${PREFIX:=/usr/local/minion}
+PREFIX=${PREFIX:=/usr/local/npg}
 
 TMPDIR=$PWD/
 TMP=$(mktemp -d ${TMPDIR:-/tmp/}$(basename -- "$0").XXXXXXXXXX)
@@ -36,9 +36,6 @@ install_tears() {
     make install
     popd
 }
-
-sudo mkdir -p "$PREFIX"
-sudo chown -R ${USER}:${USER} "$PREFIX"
 
 pushd "$TMP"
 download_tears_source

--- a/scripts/minion/make_minion_dist.sh
+++ b/scripts/minion/make_minion_dist.sh
@@ -4,13 +4,14 @@ set -eou pipefail
 
 set -x
 
-PREFIX=${PREFIX:=/usr/local/minion}
+PREFIX=${PREFIX:=/usr/local/npg}
 
-USER=${USER:=minion}
+MINION_USER=${USER:=minion}
+
 IRODS_HOST=${IRODS_HOST:=localhost}
 IRODS_ZONE=${IRODS_ZONE:=tempZone}
 IRODS_USER=${IRODS_USER:=irods}
-IRODS_HOME=${IRODS_HOME:=/$IRODS_ZONE/home/$IRODS_USER}
+IRODS_ROOT=${IRODS_ROOT:=/$IRODS_ZONE/home/$IRODS_USER}
 IRODS_DEFAULT_RESC=${IRODS_DEFAULT_RESC:=demoResc}
 
 TMPDIR=$PWD/
@@ -24,11 +25,15 @@ cleanup() {
     rm -rf "$TMP"
 }
 
-sudo apt-get install -y gcc g++ make autoconf libtool libc++-dev
+sudo apt-get install -y gcc g++ make autoconf libtool bison libc++-dev
+
+sudo mkdir -p "$PREFIX"
+sudo chown -R ${USER}:${USER} "$PREFIX"
 
 ./install_hdf5.sh
 ./install_irods.sh
 ./install_jansson.sh
+./install_jq.sh
 ./install_baton.sh
 ./install_tears.sh
 ./install_npg_irods.sh
@@ -45,6 +50,7 @@ for icommand in \
     imeta \
     imkdir \
     imv \
+    ipasswd \
     iput \
     irm ; do
     cp /usr/bin/$icommand "$PREFIX/bin/$icommand"
@@ -65,7 +71,7 @@ jq '.' <<EOF > "$PREFIX/etc/irods_environment.json"
     "irods_zone_name": "$IRODS_ZONE",
     "irods_default_resource": "$IRODS_DEFAULT_RESC",
     "irods_authentication_scheme": "native",
-    "irods_authentication_file": "/home/$USER/.irods/irods_environment.json",
+    "irods_authentication_file": "/home/$MINION_USER/.irods/irods_environment.auth",
     "irods_plugins_home": "$PREFIX/var/lib/irods/plugins/"
 }
 EOF


### PR DESCRIPTION
Changed to clone npg_irods from wtst-npg/devel.

Fixed a quoting error in make_minion_dist.sh.

Corrected the iRODS authentication file path in the iRODS config file.

Added a MINION_USER environment variable to make_minion_dist.sh to
specify the Unix user name in the iRODS config file.

Added ipasswd to the installed icommands.

Changed default install PREFIX from /usr/local/minion to /usr/local/npg.

make_minion_dist.sh is now responsible for creating a directory at PREFIX.

Added jq to the build.

Use make -j 2 to build HDF5.

Added missing HDF5_PATH setting when building Perl HDF5 module.