### PR TITLE
Bugfix to event handling on paths

### DIFF
--- a/bin/npg_irods_putstream.sh
+++ b/bin/npg_irods_putstream.sh
@@ -127,7 +127,7 @@ COLLECTION=$(dirname -- "$IRODS_PATH")
 DATA_OBJECT=$(basename -- "$IRODS_PATH")
 TIMESTAMP=$(date +'%Y:%m:%dT%H:%m:%S')
 
-TMPDIR=$PWD/
+TMPDIR=/tmp/
 TMPD=$(make_temp_dir)
 MD5_FILE="$TMPD/$DATA_OBJECT.md5"
 


### PR DESCRIPTION
Bugfix to event handling on paths added to the watched data directories. Added the missing IN_CLOSE_WRITE event and refactored logic.

Made npg_irods_putstream.sh use /tmp for temporary directories.