### PR TITLE
Run rmq_init and rmq_disconnect for Publisher object

### DIFF
--- a/lib/WTSI/NPG/HTS/BatchPublisher.pm
+++ b/lib/WTSI/NPG/HTS/BatchPublisher.pm
@@ -115,6 +115,7 @@ sub publish_file_batch {
     WTSI::NPG::iRODS::Publisher->new
       (irods                  => $self->irods,
        require_checksum_cache => $self->require_checksum_cache);
+  $publisher->rmq_init();
 
   $self->read_state;
 
@@ -190,6 +191,7 @@ sub publish_file_batch {
                    "[$num_processed / $num_files]: ", pop @stack);
     };
   }
+  $publisher->rmq_disconnect();
 
   if ($num_errors > 0) {
     $self->error("Encountered errors on $num_errors / ",
@@ -197,7 +199,6 @@ sub publish_file_batch {
   }
 
   $self->write_state;
-
   return ($num_files, $num_processed, $num_errors);
 }
 ## use critic

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -111,8 +111,10 @@ sub publish_logs {
   };
 
   my $publisher = WTSI::NPG::iRODS::Publisher->new(irods => $self->irods);
+  $publisher->rmq_init();
   my $dest = $publisher->publish($tarpath, catfile($self->dest_collection,
                                                    $self->tarfile))->str;
+  $publisher->rmq_disconnect();
   my $obj = WTSI::NPG::HTS::DataObject->new($self->irods, $dest);
 
   my @primary_avus = $self->make_avu($ID_RUN, $self->id_run);
@@ -122,7 +124,6 @@ sub publish_logs {
   if ($num_err > 0) {
     $self->logcroak("Failed to set primary metadata cleanly on '$dest'");
   }
-
   return $dest;
 }
 

--- a/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
@@ -17,7 +17,6 @@ use WTSI::NPG::HTS::LIMSFactory;
 use WTSI::NPG::HTS::Seqchksum;
 use WTSI::NPG::HTS::Types qw[AlnFormat];
 use WTSI::NPG::iRODS::Metadata;
-use WTSI::NPG::iRODS::Publisher;
 use WTSI::NPG::iRODS;
 
 with qw[

--- a/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
@@ -582,6 +582,7 @@ sub _publish_ancillary_files {
   my $publisher = WTSI::NPG::iRODS::Publisher->new
     (checksum_cache_threshold => 1_000_000_000_000,
      irods                    => $self->irods);
+  $publisher->rmq_init();
 
   my @files = (@{$self->gridion_run->list_manifest_files},
                @{$self->gridion_run->list_seq_summary_files},
@@ -604,6 +605,7 @@ sub _publish_ancillary_files {
     };
   }
 
+  $publisher->rmq_disconnect();
   return ($num_files, $num_processed, $num_errors);
 }
 

--- a/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
@@ -15,7 +15,6 @@ use WTSI::NPG::HTS::BatchPublisher;
 use WTSI::NPG::HTS::PacBio::DataObjectFactory;
 use WTSI::NPG::HTS::PacBio::MetaXMLParser;
 use WTSI::NPG::iRODS::Metadata;
-use WTSI::NPG::iRODS::Publisher;
 use WTSI::NPG::iRODS;
 
 with qw[

--- a/lib/WTSI/NPG/OM/BioNano/RunPublisher.pm
+++ b/lib/WTSI/NPG/OM/BioNano/RunPublisher.pm
@@ -122,6 +122,7 @@ sub publish {
         my $publisher = WTSI::NPG::iRODS::Publisher->new(
             irods => $self->irods,
         );
+        $publisher->rmq_init();
         my $tmp_archive_path = $self->_write_temporary_archive();
         $self->debug(q[Wrote .tar.gz archive to ], $tmp_archive_path);
         $bionano_published_obj =
@@ -133,6 +134,7 @@ sub publish {
                      $self->resultset->directory,
                      q[' to iRODS destination '],
                      $bionano_path, q[']);
+	$publisher->rmq_disconnect();
     }
 
     return $bionano_published_obj;


### PR DESCRIPTION
- When a WTSI::NPG::iRODS::Publisher object is created, run the rmq_init() and rmq_disconnect() methods for the RabbitMQ server.
- Requires a version of perl-irods-wrap for which RabbitMQ messaging is enabled for the Publisher class; see https://github.com/wtsi-npg/perl-irods-wrap/pull/158
- Requires environment variables NPG_RMQ_CONFIG and NPG_RMQ_HOST to be set to appropriate values for the RabbitMQ server; again, see perl-irods-wrap.