### PR TITLE
Add RabbitMQ PublisherFactory role and CLI options

### DIFF
--- a/bin/npg_publish_bionano_run.pl
+++ b/bin/npg_publish_bionano_run.pl
@@ -146,42 +146,45 @@ npg_publish_bionano_run
 Options:
 
   --days-ago
-  --days_ago        The number of days ago that the publication window
-                    ends. Optional, defaults to zero (the current day).
-                    Has no effect if the --runfolder_path option is used.
+  --days_ago           The number of days ago that the publication window
+                       ends. Optional, defaults to zero (the current day).
+                       Has no effect if the --runfolder_path option is used.
 
-  --days            The number of days in the publication window, ending
-                    at the day given by the --days-ago argument. Any sample
-                    data modified during this period will be considered
-                    for publication. Optional, defaults to 7 days.
-                    Has no effect if the --runfolder_path option is used.
+  --days               The number of days in the publication window, ending
+                       at the day given by the --days-ago argument. Any
+                       sample data modified during this period will be
+                       considered for publication. Optional, defaults to 7
+                       days. Has no effect if the --runfolder_path option
+                       is used.
+   --collection        The data destination root collection in iRODS.
+   --enable-rmq
+   --enable_rmq        Enable RabbitMQ messaging for file publication.
+   --exchange          Name of a RabbitMQ exchange.
+                       Optional; has no effect unless RabbitMQ is enabled.
+  --help               Display help.
 
-  --collection      The data destination root collection in iRODS.
-
-  --help            Display help.
-
-  --logconf         A log4perl configuration file. Optional.
-
+  --logconf            A log4perl configuration file. Optional.
   --output-dir
-  --output_dir      Directory for .tar.gz output. Optional; if not given,
-                    .tar.gz file will be written to a temporary directory
-                    and deleted on script exit.
+  --output_dir         Directory for .tar.gz output. Optional; if not given,
+                       .tar.gz file will be written to a temporary directory
+                       and deleted on script exit.
 
+  --routing-key-prefix
+  --routing_key_prefix Prefix for a RabbitMQ routing key.
+                       Optional; has no effect unless RabbitMQ is enabled.
   --runfolder-path
-  --runfolder_path  The instrument runfolder path to load. Incompatible
-                    with --search_dir. Optional. If neither this option
-                    nor --search_dir is given, the default value of
-                    --search_dir is used.
-
+  --runfolder_path     The instrument runfolder path to load. Incompatible
+                       with --search_dir. Optional. If neither this option
+                       nor --search_dir is given, the default value of
+                       --search_dir is used.
   --search-dir
-  --search_dir      The root directory to search for BioNano data. Search
-                    depth will be a maximum of 2 levels below the given
-                    directory. The --days_ago and --days options determine
-                    a time window for runfolders to be published.
-                    Incompatible with --runfolder_path. Optional, defaults
-                    to current working directory.
-
-  --verbose         Print messages while processing. Optional.
+  --search_dir         The root directory to search for BioNano data. Search
+                       depth will be a maximum of 2 levels below the given
+                       directory. The --days_ago and --days options determine
+                       a time window for runfolders to be published.
+                       Incompatible with --runfolder_path. Optional, defaults
+                       to current working directory.
+  --verbose            Print messages while processing. Optional.
 
 =head1 DESCRIPTION
 

--- a/bin/npg_publish_gridion_run.pl
+++ b/bin/npg_publish_gridion_run.pl
@@ -106,28 +106,34 @@ npg_publish_gridion_run --collection <path> [--debug] [--logconf <path>]
   [--tar-timeout <n>] [--verbose]
 
  Options:
-   --collection      The destination collection in iRODS.
-   --debug           Enable debug level logging. Optional, defaults to
-                     false.
+   --collection         The destination collection in iRODS.
+   --debug              Enable debug level logging. Optional, defaults to
+                        false.
+   --enable-rmq
+   --enable_rmq         Enable RabbitMQ messaging for file publication.
+   --exchange           Name of a RabbitMQ exchange.
+                        Optional; has no effect unless RabbitMQ is enabled.
    --source-dir
-   --source_dir      The instrument device directory path to watch.
-   --help            Display help.
-   --logconf         A log4perl configuration file. Optional.
+   --source_dir         The instrument device directory path to watch.
+   --help               Display help.
+   --logconf            A log4perl configuration file. Optional.
    --session-timeout
-   --session_timeout The number of seconds idle time after which a multi-file
-                     tar session will be closed. Optional, defaults to 60 * 20
-                     seconds.
+   --session_timeout    The number of seconds idle time after which a
+                        multi-file tar session will be closed. Optional,
+                        defaults to 60 * 20 seconds.
    --tar-capacity
-   --tar_capacity    The number of read files to be archived per tar file.
-                     Optional, defaults to 10,000.
+   --tar_capacity       The number of read files to be archived per tar file.
+                        Optional, defaults to 10,000.
    --tar-duration
-   --tar_duration    The maximum number of seconds a tar file may be open for
-                     writing. Optional, defaults to 60 * 60 * 6 seconds.
+   --tar_duration       The maximum number of seconds a tar file may be
+                        open for writing. Optional, defaults to
+                        60 * 60 * 6 seconds.
    --tar-timeout
-   --tar_timeout     The number of seconds idle time after which a tar file
-                     open for writing, will be closed. even if it has not
-                     reached capacity. Optional, defaults to 60 * 5 seconds.
-   --verbose         Print messages while processing. Optional.
+   --tar_timeout        The number of seconds idle time, after which a tar
+                        file open for writing will be closed, even if it
+                        has not reached capacity. Optional, defaults to
+                        60 * 5 seconds.
+   --verbose            Print messages while processing. Optional.
 
 =head1 DESCRIPTION
 

--- a/bin/npg_publish_illumina_logs.pl
+++ b/bin/npg_publish_illumina_logs.pl
@@ -17,20 +17,27 @@ our $VERSION = '';
 
 my $collection;
 my $debug;
+my $enable_rmq;
+my $exchange;
 my $id_run;
 my $log4perl_config;
+my $routing_key_prefix;
 my $runfolder_path;
+
 my $verbose;
 
-GetOptions('collection=s'                      => \$collection,
-           'debug'                             => \$debug,
-           'help'                              => sub {
+GetOptions('collection=s'                            => \$collection,
+           'debug'                                   => \$debug,
+           'enable-rmq|enable_rmq'                   => \$enable_rmq,
+           'exchange=s'                              => \$exchange,
+           'help'                                    => sub {
              pod2usage(-verbose => 2, -exitval => 0);
            },
-           'id_run|id-run=i'                   => \$id_run,
-           'logconf=s'                         => \$log4perl_config,
-           'runfolder-path|runfolder_path=s'   => \$runfolder_path,
-           'verbose'                           => \$verbose);
+           'id_run|id-run=i'                         => \$id_run,
+           'logconf=s'                               => \$log4perl_config,
+           'routing-key-prefix|routing_key_prefix=s' => \$routing_key_prefix,
+           'runfolder-path|runfolder_path=s'         => \$runfolder_path,
+           'verbose'                                 => \$verbose);
 
 # Process CLI arguments
 if ($log4perl_config) {
@@ -56,6 +63,16 @@ if ($collection) {
 if (defined $id_run) {
   push @init_args, id_run => $id_run;
 }
+if ($enable_rmq) {
+    push @init_args, enable_rmq => 1;
+    if (defined $exchange) {
+        push @init_args, exchange => $exchange;
+    }
+    if (defined $routing_key_prefix) {
+        push @init_args, routing_key_prefix => $routing_key_prefix;
+    }
+}
+
 
 my $log = Log::Log4perl->get_logger('main');
 $log->level($ALL);

--- a/bin/npg_publish_illumina_logs.pl
+++ b/bin/npg_publish_illumina_logs.pl
@@ -94,15 +94,22 @@ npg_publish_illumina_logs --runfolder-path <path> [--collection <path>]
   [--id-run <id_run>] [--debug] [--verbose] [--logconf <path>]
 
  Options:
-   --collection      The destination collection in iRODS. Optional,
-                     defaults to /seq/<id_run>/log.
-   --debug           Enable debug level logging. Optional, defaults to
-                     false.
-   --help            Display help.
+   --collection         The destination collection in iRODS. Optional,
+                        defaults to /seq/<id_run>/log.
+   --debug              Enable debug level logging. Optional, defaults to
+                        false.
+   --enable-rmq
+   --enable_rmq         Enable RabbitMQ messaging for file publication.
+   --exchange           Name of a RabbitMQ exchange.
+                        Optional; has no effect unless RabbitMQ is enabled.
+   --help               Display help.
+   --routing-key-prefix
+   --routing_key_prefix Prefix for a RabbitMQ routing key.
+                        Optional; has no effect unless RabbitMQ is enabled.
    --runfolder-path
-   --runfolder_path  The instrument runfolder path to load.
-   --logconf         A log4perl configuration file. Optional.
-   --verbose         Print messages while processing. Optional.
+   --runfolder_path     The instrument runfolder path to load.
+   --logconf            A log4perl configuration file. Optional.
+   --verbose            Print messages while processing. Optional.
 
 =head1 DESCRIPTION
 

--- a/bin/npg_publish_illumina_run.pl
+++ b/bin/npg_publish_illumina_run.pl
@@ -285,11 +285,21 @@ npg_publish_illumina_run --runfolder-path <path> [--collection <path>]
 
  Advanced options:
 
-  --driver-type
-  --driver_type Set the lims driver type to a custom value. The default
-                is driver type is 'ml_warehouse_fc_cache' (defined by
-                WTSI::NPG::HTS::LIMSFactory). Other st::spi::lims driver
-                types may be used e.g. 'samplesheet'.
+   --driver-type
+   --driver_type Set the lims driver type to a custom value. The default
+                 is driver type is 'ml_warehouse_fc_cache' (defined by
+                 WTSI::NPG::HTS::LIMSFactory). Other st::spi::lims driver
+                 types may be used e.g. 'samplesheet'.
+
+ RabbitMQ options:
+   --enable-rmq
+   --enable_rmq         Enable RabbitMQ messaging for file publication.
+   --exchange           Name of a RabbitMQ exchange.
+                        Optional; has no effect unless RabbitMQ is enabled.
+   --routing-key-prefix
+   --routing_key_prefix Prefix for a RabbitMQ routing key.
+                        Optional; has no effect unless RabbitMQ is enabled.
+
 
 =head1 DESCRIPTION
 

--- a/bin/npg_publish_illumina_run.pl
+++ b/bin/npg_publish_illumina_run.pl
@@ -48,6 +48,8 @@ my $archive_path;
 my $collection;
 my $debug;
 my $driver_type;
+my $enable_rmq;
+my $exchange;
 my $file_format;
 my $force = 0;
 my $id_run;
@@ -57,35 +59,39 @@ my $log4perl_config;
 my $max_errors = 0;
 my $qc = 1;
 my $restart_file;
+my $routing_key_prefix;
 my $runfolder_path;
 my $verbose;
 my $xml = 1;
 
 my @positions;
 
-GetOptions('alignment!'                        => \$alignment,
-           'alt-process|alt_process=s'         => \$alt_process,
-           'ancillary!'                        => \$ancillary,
-           'archive-path|archive_path=s'       => \$archive_path,
-           'collection=s'                      => \$collection,
-           'debug'                             => \$debug,
-           'driver-type|driver_type=s'         => \$driver_type,
-           'file-format|file_format=s'         => \$file_format,
-           'force'                             => \$force,
-           'help'                              => sub {
-             pod2usage(-verbose => 2, -exitval => 0);
+GetOptions('alignment!'                              => \$alignment,
+           'alt-process|alt_process=s'               => \$alt_process,
+           'ancillary!'                              => \$ancillary,
+           'archive-path|archive_path=s'             => \$archive_path,
+           'collection=s'                            => \$collection,
+           'debug'                                   => \$debug,
+           'enable-rmq|enable_rmq'                   => \$enable_rmq,
+           'exchange=s'                              => \$exchange,
+           'driver-type|driver_type=s'               => \$driver_type,
+           'file-format|file_format=s'               => \$file_format,
+           'force'                                   => \$force,
+           'help'                                    => sub {
+               pod2usage(-verbose => 2, -exitval => 0);
            },
-           'id_run|id-run=i'                   => \$id_run,
-           'index!'                            => \$index,
-           'interop!'                          => \$interop,
-           'logconf=s'                         => \$log4perl_config,
-           'max-errors|max_errors=i'           => \$max_errors,
-           'lanes|positions=i'                 => \@positions,
-           'qc!'                               => \$qc,
-           'restart-file|restart_file=s'       => \$restart_file,
-           'runfolder-path|runfolder_path=s'   => \$runfolder_path,
-           'verbose'                           => \$verbose,
-           'xml!'                              => \$xml);
+           'id_run|id-run=i'                         => \$id_run,
+           'index!'                                  => \$index,
+           'interop!'                                => \$interop,
+           'logconf=s'                               => \$log4perl_config,
+           'max-errors|max_errors=i'                 => \$max_errors,
+           'lanes|positions=i'                       => \@positions,
+           'qc!'                                     => \$qc,
+           'restart-file|restart_file=s'             => \$restart_file,
+           'routing-key-prefix|routing_key_prefix=s' => \$routing_key_prefix,
+           'runfolder-path|runfolder_path=s'         => \$runfolder_path,
+           'verbose'                                 => \$verbose,
+           'xml!'                                    => \$xml);
 
 # Process CLI arguments
 if ($log4perl_config) {
@@ -155,6 +161,15 @@ if ($restart_file) {
 }
 if ($max_errors) {
   push @pub_init_args, max_errors => $max_errors;
+}
+if ($enable_rmq) {
+    push @pub_init_args, enable_rmq => 1;
+    if (defined $exchange) {
+        push @pub_init_args, exchange => $exchange;
+    }
+    if (defined $routing_key_prefix) {
+        push @pub_init_args, routing_key_prefix => $routing_key_prefix;
+    }
 }
 
 my $publisher = WTSI::NPG::HTS::Illumina::RunPublisher->new(@pub_init_args);

--- a/bin/npg_publish_pacbio_run.pl
+++ b/bin/npg_publish_pacbio_run.pl
@@ -149,19 +149,26 @@ npg_publish_pacbio_run --runfolder-path <path> [--collection <path>]
   [--force] [--debug] [--verbose] [--logconf <path>] [--sequel]
 
  Options:
-   --collection      The destination collection in iRODS. Optional,
-                     defaults to /seq/pacbio/.
-   --debug           Enable debug level logging. Optional, defaults to
-                     false.
-   --force           Force an attempt to re-publish files that have been
-                     published successfully.
-   --help            Display help.
+   --collection         The destination collection in iRODS. Optional,
+                        defaults to /seq/pacbio/.
+   --debug              Enable debug level logging. Optional, defaults to
+                        false.
+   --enable-rmq
+   --enable_rmq         Enable RabbitMQ messaging for file publication.
+   --exchange           Name of a RabbitMQ exchange.
+                        Optional; has no effect unless RabbitMQ is enabled.
+   --force              Force an attempt to re-publish files that have been
+                        published successfully.
+   --help               Display help.
+   --routing-key-prefix
+   --routing_key_prefix Prefix for a RabbitMQ routing key.
+                        Optional; has no effect unless RabbitMQ is enabled.
    --runfolder-path
-   --runfolder_path  The instrument runfolder path to load.
-   --logconf         A log4perl configuration file. Optional.
-   --verbose         Print messages while processing. Optional.
-   --sequel          If the run folder is output from a PacBio Sequel 
-                     system. Optional.
+   --runfolder_path     The instrument runfolder path to load.
+   --logconf            A log4perl configuration file. Optional.
+   --verbose            Print messages while processing. Optional.
+   --sequel             If the run folder is output from a PacBio Sequel
+                        system. Optional.
 
 =head1 DESCRIPTION
 

--- a/bin/npg_publish_pacbio_run.pl
+++ b/bin/npg_publish_pacbio_run.pl
@@ -40,22 +40,28 @@ LOGCONF
 
 my $collection;
 my $debug;
+my $enable_rmq;
+my $exchange;
 my $force = 0;
 my $log4perl_config;
+my $routing_key_prefix;
 my $runfolder_path;
 my $verbose;
 my $sequel;
 
-GetOptions('collection=s'                    => \$collection,
-           'debug'                           => \$debug,
-           'force'                           => \$force,
-           'help'                            => sub {
+GetOptions('collection=s'                            => \$collection,
+           'debug'                                   => \$debug,
+           'enable-rmq|enable_rmq'                   => \$enable_rmq,
+           'exchange=s'                              => \$exchange,
+           'force'                                   => \$force,
+           'help'                                    => sub {
              pod2usage(-verbose => 2, -exitval => 0);
            },
-           'sequel'                          => \$sequel,
-           'logconf=s'                       => \$log4perl_config,
-           'runfolder-path|runfolder_path=s' => \$runfolder_path,
-           'verbose'                         => \$verbose);
+           'sequel'                                  => \$sequel,
+           'logconf=s'                               => \$log4perl_config,
+           'routing-key-prefix|routing_key_prefix=s' => \$routing_key_prefix,
+           'runfolder-path|runfolder_path=s'         => \$runfolder_path,
+           'verbose'                                 => \$verbose);
 
 
 
@@ -96,6 +102,15 @@ my @init_args = (force          => $force,
                  runfolder_path => $runfolder_path);
 if ($collection) {
   push @init_args, dest_collection => $collection;
+}
+if ($enable_rmq) {
+    push @init_args, enable_rmq => 1;
+    if (defined $exchange) {
+        push @init_args, exchange => $exchange;
+    }
+    if (defined $routing_key_prefix) {
+        push @init_args, routing_key_prefix => $routing_key_prefix;
+    }
 }
 
 my $publisher = $module->new(@init_args);

--- a/lib/WTSI/NPG/HTS/BatchPublisher.pm
+++ b/lib/WTSI/NPG/HTS/BatchPublisher.pm
@@ -12,11 +12,11 @@ use Try::Tiny;
 
 use WTSI::DNAP::Utilities::Params qw[function_params];
 use WTSI::NPG::HTS::DefaultDataObjectFactory;
-use WTSI::NPG::iRODS::Publisher;
 
 with qw[
          WTSI::DNAP::Utilities::Loggable
          WTSI::DNAP::Utilities::JSONCodec
+         WTSI::NPG::iRODS::PublisherFactory
        ];
 
 our $VERSION = '';
@@ -111,10 +111,9 @@ sub publish_file_batch {
 
   $extra_avus_callback ||= sub { return };
 
-  my $publisher =
-    WTSI::NPG::iRODS::Publisher->new
-      (irods                  => $self->irods,
-       require_checksum_cache => $self->require_checksum_cache);
+  my $publisher = $self->make_publisher(
+      irods                  => $self->irods,
+      require_checksum_cache => $self->require_checksum_cache);
 
   $self->read_state;
 

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -11,12 +11,12 @@ use Try::Tiny;
 
 use WTSI::NPG::HTS::DataObject;
 use WTSI::NPG::iRODS::Metadata qw[$ID_RUN];
-use WTSI::NPG::iRODS::Publisher;
 use WTSI::NPG::iRODS;
 
 with qw[
          WTSI::DNAP::Utilities::Loggable
          WTSI::NPG::iRODS::Annotator
+         WTSI::NPG::iRODS::PublisherFactory
          npg_tracking::illumina::run::short_info
          npg_tracking::illumina::run::folder
        ];
@@ -110,7 +110,7 @@ sub publish_logs {
     $self->logcroak(pop @stack); # Use a shortened error message
   };
 
-  my $publisher = WTSI::NPG::iRODS::Publisher->new(irods => $self->irods);
+  my $publisher = $self->make_publisher(irods => $self->irods);
   my $dest = $publisher->publish($tarpath, catfile($self->dest_collection,
                                                    $self->tarfile))->str;
   my $obj = WTSI::NPG::HTS::DataObject->new($self->irods, $dest);

--- a/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
@@ -25,6 +25,7 @@ with qw[
          WTSI::DNAP::Utilities::JSONCodec
          WTSI::NPG::HTS::PathLister
          WTSI::NPG::HTS::Illumina::Annotator
+         WTSI::NPG::iRODS::PublisherFactory
          npg_tracking::illumina::run::short_info
          npg_tracking::illumina::run::folder
        ];
@@ -1388,12 +1389,16 @@ sub _build_obj_factory {
 sub _build_batch_publisher {
   my ($self) = @_;
 
-  my @init_args = (force       => $self->force,
-                   irods       => $self->irods,
-                   obj_factory => $self->obj_factory,
-                   state_file  => $self->restart_file);
+  my @init_args = (force              => $self->force,
+                   irods              => $self->irods,
+                   obj_factory        => $self->obj_factory,
+                   state_file         => $self->restart_file,
+                   enable_rmq         => $self->enable_rmq,
+                   exchange           => $self->exchange,
+                   routing_key_prefix => $self->routing_key_prefix,
+               );
   if ($self->has_max_errors) {
-    push @init_args, max_errors  => $self->max_errors;
+    push @init_args, max_errors => $self->max_errors;
   }
 
   return WTSI::NPG::HTS::BatchPublisher->new(@init_args);

--- a/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
@@ -28,7 +28,6 @@ use WTSI::NPG::HTS::ONT::TarDataObject;
 use WTSI::NPG::HTS::TarPublisher;
 use WTSI::NPG::iRODS::Collection;
 use WTSI::NPG::iRODS::Metadata;
-use WTSI::NPG::iRODS::Publisher;
 use WTSI::NPG::iRODS;
 
 with qw[
@@ -36,6 +35,7 @@ with qw[
          WTSI::NPG::Accountable
          WTSI::NPG::iRODS::Annotator
          WTSI::NPG::iRODS::Utilities
+         WTSI::NPG::iRODS::PublisherFactory
          WTSI::NPG::HTS::ArchiveSession
          WTSI::NPG::HTS::ONT::Annotator
          WTSI::NPG::HTS::ONT::Watcher
@@ -579,7 +579,7 @@ sub _publish_ancillary_files {
   # This is a hack. At this time there is no flag to disable md5 cache
   # files. However, we can limit their creation to files above a
   # certain size and make that size unfeasibly large.
-  my $publisher = WTSI::NPG::iRODS::Publisher->new
+  my $publisher = $self->make_publisher
     (checksum_cache_threshold => 1_000_000_000_000,
      irods                    => $self->irods);
 

--- a/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
@@ -15,7 +15,6 @@ use WTSI::NPG::HTS::BatchPublisher;
 use WTSI::NPG::HTS::PacBio::DataObjectFactory;
 use WTSI::NPG::HTS::PacBio::MetaXMLParser;
 use WTSI::NPG::iRODS::Metadata;
-use WTSI::NPG::iRODS::Publisher;
 use WTSI::NPG::iRODS;
 
 with qw[
@@ -23,6 +22,7 @@ with qw[
          WTSI::NPG::HTS::PathLister
          WTSI::NPG::HTS::PacBio::Annotator
          WTSI::NPG::HTS::PacBio::MetaQuery
+         WTSI::NPG::iRODS::PublisherFactory
        ];
 
 our $VERSION = '';
@@ -535,6 +535,9 @@ sub _build_batch_publisher {
      irods                  => $self->irods,
      obj_factory            => $self->obj_factory,
      state_file             => $self->restart_file,
+     enable_rmq             => $self->enable_rmq,
+     exchange               => $self->exchange,
+     routing_key_prefix     => $self->routing_key_prefix,
      require_checksum_cache => []); ## no md5s precreated for PacBio
 }
 

--- a/lib/WTSI/NPG/OM/BioNano/RunPublisher.pm
+++ b/lib/WTSI/NPG/OM/BioNano/RunPublisher.pm
@@ -16,7 +16,6 @@ use WTSI::NPG::iRODS;
 use WTSI::NPG::iRODS::Collection;
 use WTSI::NPG::iRODS::DataObject;
 use WTSI::NPG::iRODS::Metadata;
-use WTSI::NPG::iRODS::Publisher;
 use WTSI::NPG::OM::BioNano::ResultSet;
 
 # FIXME Move/refactor WTSI::NPG::HTS::Publisher to reflect use outside of
@@ -31,6 +30,7 @@ our $PIGZ_PROCESSES = 4;
 
 with qw[WTSI::DNAP::Utilities::Loggable
         WTSI::NPG::Accountable
+        WTSI::NPG::iRODS::PublisherFactory
         WTSI::NPG::OM::BioNano::Annotator];
 
 has 'directory' =>
@@ -119,7 +119,7 @@ sub publish {
             $self->resultset,
             @stock_records,
         );
-        my $publisher = WTSI::NPG::iRODS::Publisher->new(
+        my $publisher = $self->make_publisher(
             irods => $self->irods,
         );
         my $tmp_archive_path = $self->_write_temporary_archive();


### PR DESCRIPTION
- Depends on in-progress changes to perl-irods-wrap: https://github.com/wtsi-npg/perl-irods-wrap/pull/162
- Scripts have options to explicitly enable/disable RabbitMQ and input parameters
- Publisher classes consume the PublisherFactory role, used to create a PublisherWithReporting or Publisher, with or without RMQ respectively
- Tests passing with appropriate version of perl-irods-wrap