### PR TITLE
RabbitMQ: PublisherFactory and CLI options

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -34,6 +34,8 @@ lib/WTSI/NPG/HTS/AlFilter.pm
 lib/WTSI/NPG/HTS/ArchiveSession.pm
 lib/WTSI/NPG/HTS/AVUCollator.pm
 lib/WTSI/NPG/HTS/BatchPublisher.pm
+lib/WTSI/NPG/HTS/BatchPublisherFactory.pm
+lib/WTSI/NPG/HTS/BatchPublisherWithReporting.pm
 lib/WTSI/NPG/HTS/DataObject.pm
 lib/WTSI/NPG/HTS/DataObjectFactory.pm
 lib/WTSI/NPG/HTS/DefaultDataObjectFactory.pm
@@ -104,6 +106,7 @@ scripts/travis_install.sh
 scripts/travis_script.sh
 t/aln_data_object.t
 t/anc_data_object.t
+t/batch_publisher_factory.t
 t/bionano_bnx_file.t
 t/bionano_result_set.t
 t/bionano_run_finder.t
@@ -15356,6 +15359,7 @@ t/illumina_meta_updater.t
 t/lib/WTSI/DNAP/Utilities/ParamsTest.pm
 t/lib/WTSI/NPG/DataSub/MetaUpdaterTest.pm
 t/lib/WTSI/NPG/DataSub/SubtrackClientTest.pm
+t/lib/WTSI/NPG/HTS/BatchPublisherFactoryTest.pm
 t/lib/WTSI/NPG/HTS/HeaderParserTest.pm
 t/lib/WTSI/NPG/HTS/Illumina/AlnDataObjectTest.pm
 t/lib/WTSI/NPG/HTS/Illumina/AncDataObjectTest.pm
@@ -15375,6 +15379,7 @@ t/lib/WTSI/NPG/HTS/PacBio/Sequel/RunMonitorTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/Sequel/RunPublisherTest.pm
 t/lib/WTSI/NPG/HTS/SeqchksumTest.pm
 t/lib/WTSI/NPG/HTS/Test.pm
+t/lib/WTSI/NPG/HTS/TestRabbitMQ.pm
 t/lib/WTSI/NPG/OM/BioNano/BnxFileTest.pm
 t/lib/WTSI/NPG/OM/BioNano/ResultSetTest.pm
 t/lib/WTSI/NPG/OM/BioNano/RunFinderTest.pm

--- a/bin/npg_publish_illumina_logs.pl
+++ b/bin/npg_publish_illumina_logs.pl
@@ -15,22 +15,31 @@ use WTSI::NPG::iRODS;
 
 our $VERSION = '';
 
+my $channel;
 my $collection;
 my $debug;
+my $enable_rmq;
+my $exchange;
 my $id_run;
 my $log4perl_config;
+my $routing_key_prefix;
 my $runfolder_path;
+
 my $verbose;
 
-GetOptions('collection=s'                      => \$collection,
-           'debug'                             => \$debug,
-           'help'                              => sub {
+GetOptions('channel=i'                               => \$channel,
+           'collection=s'                            => \$collection,
+           'debug'                                   => \$debug,
+           'enable-rmq|enable_rmq'                   => \$enable_rmq,
+           'exchange=s'                              => \$exchange,
+           'help'                                    => sub {
              pod2usage(-verbose => 2, -exitval => 0);
            },
-           'id_run|id-run=i'                   => \$id_run,
-           'logconf=s'                         => \$log4perl_config,
-           'runfolder-path|runfolder_path=s'   => \$runfolder_path,
-           'verbose'                           => \$verbose);
+           'id_run|id-run=i'                         => \$id_run,
+           'logconf=s'                               => \$log4perl_config,
+           'routing-key-prefix|routing_key_prefix=s' => \$routing_key_prefix,
+           'runfolder-path|runfolder_path=s'         => \$runfolder_path,
+           'verbose'                                 => \$verbose);
 
 # Process CLI arguments
 if ($log4perl_config) {
@@ -56,6 +65,19 @@ if ($collection) {
 if (defined $id_run) {
   push @init_args, id_run => $id_run;
 }
+if ($enable_rmq) {
+    push @init_args, enable_rmq => 1;
+    if (defined $channel) {
+        push @init_args, channel => $channel;
+    }
+    if (defined $exchange) {
+        push @init_args, exchange => $exchange;
+    }
+    if (defined $routing_key_prefix) {
+        push @init_args, routing_key_prefix => $routing_key_prefix;
+    }
+}
+
 
 my $log = Log::Log4perl->get_logger('main');
 $log->level($ALL);
@@ -77,15 +99,24 @@ npg_publish_illumina_logs --runfolder-path <path> [--collection <path>]
   [--id-run <id_run>] [--debug] [--verbose] [--logconf <path>]
 
  Options:
-   --collection      The destination collection in iRODS. Optional,
-                     defaults to /seq/<id_run>/log.
-   --debug           Enable debug level logging. Optional, defaults to
-                     false.
-   --help            Display help.
+   --channel            A RabbitMQ channel number.
+                        Optional; has no effect unless RabbitMQ is enabled.
+   --collection         The destination collection in iRODS. Optional,
+                        defaults to /seq/<id_run>/log.
+   --debug              Enable debug level logging. Optional, defaults to
+                        false.
+   --enable-rmq
+   --enable_rmq         Enable RabbitMQ messaging for file publication.
+   --exchange           Name of a RabbitMQ exchange.
+                        Optional; has no effect unless RabbitMQ is enabled.
+   --help               Display help.
+   --routing-key-prefix
+   --routing_key_prefix Prefix for a RabbitMQ routing key.
+                        Optional; has no effect unless RabbitMQ is enabled.
    --runfolder-path
-   --runfolder_path  The instrument runfolder path to load.
-   --logconf         A log4perl configuration file. Optional.
-   --verbose         Print messages while processing. Optional.
+   --runfolder_path     The instrument runfolder path to load.
+   --logconf            A log4perl configuration file. Optional.
+   --verbose            Print messages while processing. Optional.
 
 =head1 DESCRIPTION
 
@@ -94,11 +125,11 @@ sequencing run into iRODS.
 
 =head1 AUTHOR
 
-Keith James <kdj@sanger.ac.uk>
+Keith James <kdj@sanger.ac.uk>, Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2016 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2016, 2017 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/bin/npg_publish_pacbio_run.pl
+++ b/bin/npg_publish_pacbio_run.pl
@@ -38,24 +38,32 @@ log4perl.oneMessagePerAppender = 1
 LOGCONF
 ;
 
+my $channel;
 my $collection;
 my $debug;
+my $enable_rmq;
+my $exchange;
 my $force = 0;
 my $log4perl_config;
+my $routing_key_prefix;
 my $runfolder_path;
 my $verbose;
 my $sequel;
 
-GetOptions('collection=s'                    => \$collection,
-           'debug'                           => \$debug,
-           'force'                           => \$force,
-           'help'                            => sub {
+GetOptions('channel=i'                               => \$channel,
+           'collection=s'                            => \$collection,
+           'debug'                                   => \$debug,
+           'enable-rmq|enable_rmq'                   => \$enable_rmq,
+           'exchange=s'                              => \$exchange,
+           'force'                                   => \$force,
+           'help'                                    => sub {
              pod2usage(-verbose => 2, -exitval => 0);
            },
-           'sequel'                          => \$sequel,
-           'logconf=s'                       => \$log4perl_config,
-           'runfolder-path|runfolder_path=s' => \$runfolder_path,
-           'verbose'                         => \$verbose);
+           'sequel'                                  => \$sequel,
+           'logconf=s'                               => \$log4perl_config,
+           'routing-key-prefix|routing_key_prefix=s' => \$routing_key_prefix,
+           'runfolder-path|runfolder_path=s'         => \$runfolder_path,
+           'verbose'                                 => \$verbose);
 
 
 
@@ -97,6 +105,18 @@ my @init_args = (force          => $force,
 if ($collection) {
   push @init_args, dest_collection => $collection;
 }
+if ($enable_rmq) {
+    push @init_args, enable_rmq => 1;
+    if (defined $channel) {
+        push @init_args, channel => $channel;
+    }
+    if (defined $exchange) {
+        push @init_args, exchange => $exchange;
+    }
+    if (defined $routing_key_prefix) {
+        push @init_args, routing_key_prefix => $routing_key_prefix;
+    }
+}
 
 my $publisher = $module->new(@init_args);
 
@@ -134,19 +154,28 @@ npg_publish_pacbio_run --runfolder-path <path> [--collection <path>]
   [--force] [--debug] [--verbose] [--logconf <path>] [--sequel]
 
  Options:
-   --collection      The destination collection in iRODS. Optional,
-                     defaults to /seq/pacbio/.
-   --debug           Enable debug level logging. Optional, defaults to
-                     false.
-   --force           Force an attempt to re-publish files that have been
-                     published successfully.
-   --help            Display help.
+   --channel            A RabbitMQ channel number.
+                        Optional; has no effect unless RabbitMQ is enabled.
+   --collection         The destination collection in iRODS. Optional,
+                        defaults to /seq/pacbio/.
+   --debug              Enable debug level logging. Optional, defaults to
+                        false.
+   --enable-rmq
+   --enable_rmq         Enable RabbitMQ messaging for file publication.
+   --exchange           Name of a RabbitMQ exchange.
+                        Optional; has no effect unless RabbitMQ is enabled.
+   --force              Force an attempt to re-publish files that have been
+                        published successfully.
+   --help               Display help.
+   --routing-key-prefix
+   --routing_key_prefix Prefix for a RabbitMQ routing key.
+                        Optional; has no effect unless RabbitMQ is enabled.
    --runfolder-path
-   --runfolder_path  The instrument runfolder path to load.
-   --logconf         A log4perl configuration file. Optional.
-   --verbose         Print messages while processing. Optional.
-   --sequel          If the run folder is output from a PacBio Sequel 
-                     system. Optional.
+   --runfolder_path     The instrument runfolder path to load.
+   --logconf            A log4perl configuration file. Optional.
+   --verbose            Print messages while processing. Optional.
+   --sequel             If the run folder is output from a PacBio Sequel
+                        system. Optional.
 
 =head1 DESCRIPTION
 
@@ -177,7 +206,7 @@ file, for all available SMRT cells.
 
 =head1 AUTHOR
 
-Keith James <kdj@sanger.ac.uk>
+Keith James <kdj@sanger.ac.uk>, Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 

--- a/lib/WTSI/NPG/HTS/BatchPublisherFactory.pm
+++ b/lib/WTSI/NPG/HTS/BatchPublisherFactory.pm
@@ -1,0 +1,165 @@
+package WTSI::NPG::HTS::BatchPublisherFactory;
+
+use strict;
+use warnings;
+use Moose;
+
+use WTSI::NPG::HTS::BatchPublisher;
+
+with qw [WTSI::NPG::iRODS::Reportable::ConfigurableForRabbitMQ
+         WTSI::DNAP::Utilities::Loggable
+    ];
+
+our $VERSION = '';
+
+
+has 'force' =>
+  (isa           => 'Bool',
+   is            => 'ro',
+   required      => 0,
+   default       => 0,
+   documentation => 'Force re-publication of files that have been published');
+
+has 'irods' =>
+  (isa           => 'WTSI::NPG::iRODS',
+   is            => 'ro',
+   required      => 1,
+   documentation => 'An iRODS handle to run searches and perform updates');
+
+has 'max_errors' =>
+  (isa       => 'Int',
+   is        => 'ro',
+   required  => 0,
+   predicate => 'has_max_errors',
+   documentation => 'The maximum number of errors permitted before ' .
+                    'the remainder of a publishing process is aborted');
+
+has 'obj_factory' =>
+  (does          => 'WTSI::NPG::HTS::DataObjectFactory',
+   is            => 'ro',
+   required      => 1,
+   lazy          => 1,
+   builder       => '_build_obj_factory',
+   documentation => 'A factory building data objects from files');
+
+has 'require_checksum_cache' =>
+  (is            => 'ro',
+   isa           => 'ArrayRef[Str]',
+   required      => 1,
+   default       => sub { return [qw[bam cram]] },
+   documentation => 'A list of file suffixes for which MD5 cache files ' .
+                    'must be provided and will not be created on the fly');
+
+has 'restart_file' =>
+  (isa           => 'Str',
+   is            => 'ro',
+   required      => 1,
+   documentation => 'A file containing a record of files successfully ' .
+                    'published');
+
+
+
+=head2 make_batch_publisher
+
+  Args [n]   : Arguments for creation of the BatchPublisher object.
+
+  Example    : my $publisher = $factory->make_batch_publisher();
+
+  Description: Factory for creating BatchPublisher objects of an appropriate
+               class, depending if RabbitMQ messaging is enabled. Arguments
+               for Publisher construction are derived from class attributes.
+
+  Returntype : WTSI::NPG::HTS::BatchPublisher or
+               WTSI::NPG::HTS::BatchPublisherWithReporting
+
+=cut
+
+sub make_batch_publisher {
+
+    my ($self, ) = @_;
+    my @args;
+    if ($self->enable_rmq) {
+        push @args, 'enable_rmq'         => 1;
+        push @args, 'channel'            => $self->channel;
+        push @args, 'exchange'           => $self->exchange;
+        push @args, 'routing_key_prefix' => $self->routing_key_prefix;
+    }
+    if ($self->has_max_errors) {
+        push @args, 'max_errors'         => $self->max_errors;
+    }
+    push @args, 'force'                  => $self->force;
+    push @args, 'irods'                  => $self->irods;
+    push @args, 'obj_factory'            => $self->obj_factory;
+    push @args, 'require_checksum_cache' => $self->require_checksum_cache;
+    push @args, 'state_file'             => $self->restart_file;
+
+    my $batch_pub;
+    if ($self->enable_rmq) {
+        # 'require' ensures BatchPublisherWithReporting not used unless wanted
+        # eg. prerequisite module Net::AMQP::RabbitMQ may not be installed
+        require WTSI::NPG::HTS::BatchPublisherWithReporting;
+        $batch_pub = WTSI::NPG::HTS::BatchPublisherWithReporting->new(@args);
+    } else {
+        $batch_pub = WTSI::NPG::HTS::BatchPublisher->new(@args);
+    }
+    return $batch_pub;
+}
+
+sub _build_obj_factory {
+  my ($self) = @_;
+
+  return WTSI::NPG::HTS::DefaultDataObjectFactory->new(irods => $self->irods);
+}
+
+
+no Moose;
+
+1;
+
+
+
+__END__
+
+=head1 NAME
+
+WTSI::NPG::HTS::BatchPublisherFactory
+
+=head1 DESCRIPTION
+
+A Role for creating BatchPublisher objects of an appropriate class:
+
+=over
+
+=item
+
+WTSI::NPG::HTS::BatchPublisherWithReporting if RabbitMQ is enabled;
+
+=item
+
+WTSI::NPG::HTS::BatchPublisher otherwise.
+
+=back
+
+
+RabbitMQ is enabled if the attribute enable_rmq is true; disabled otherwise.
+
+
+=head1 AUTHOR
+
+Iain Bancarz <ib5@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2018 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/lib/WTSI/NPG/HTS/BatchPublisherWithReporting.pm
+++ b/lib/WTSI/NPG/HTS/BatchPublisherWithReporting.pm
@@ -1,0 +1,66 @@
+package WTSI::NPG::HTS::BatchPublisherWithReporting;
+
+use namespace::autoclean;
+use Moose;
+
+our $VERSION = '';
+
+extends 'WTSI::NPG::HTS::BatchPublisher';
+
+with 'WTSI::NPG::iRODS::Reportable::PublisherMQ';
+
+sub BUILD {
+    my ($self, ) = @_;
+    return $self->rmq_init();
+}
+
+sub DEMOLISH {
+    my ($self, ) = @_;
+    return $self->rmq_disconnect();
+}
+
+
+__PACKAGE__->meta->make_immutable;
+
+no Moose;
+
+1;
+
+
+
+__END__
+
+=head1 NAME
+
+WTSI::NPG::HTS::BatchPublisherWithReporting
+
+=head1 DESCRIPTION
+
+A BatchPublisher class which reports file publication to a RabbitMQ server.
+
+An instance is capable of publishing a list of files ("a batch") per
+call to 'publish_file_batch'. The instance keeps track of the success
+or failure of publishing each file it processes. Files which have
+published successfully in any previous batch are skipped (they are
+not even checked against iRODS for checksum matches and correct
+metadata) unless the force attribute is set true.
+
+=head1 AUTHOR
+
+Iain Bancarz <ib5@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2018 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/lib/WTSI/NPG/HTS/DataObjectFactory.pm
+++ b/lib/WTSI/NPG/HTS/DataObjectFactory.pm
@@ -35,11 +35,11 @@ factory will determine what class(es) of data object to construct.
 
 =head1 AUTHOR
 
-Keith James <kdj@sanger.ac.uk>
+Keith James <kdj@sanger.ac.uk>, Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2016 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2016, 2018 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/HTS/Illumina/DataObjectFactory.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/DataObjectFactory.pm
@@ -22,7 +22,8 @@ has 'irods' =>
   (is            => 'ro',
    isa           => 'WTSI::NPG::iRODS',
    required      => 1,
-   default       => sub { return WTSI::NPG::iRODS->new },
+   lazy          => 1,
+   builder       => '_build_irods',
    documentation => 'The iRODS connection handle');
 
 has 'ancillary_formats' =>
@@ -114,6 +115,11 @@ my $interop_regex = qr{[.]bin$}msx;
 
     return $obj;
   }
+
+  sub _build_irods {
+    return WTSI::NPG::iRODS->new;
+  }
+
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
@@ -11,7 +11,7 @@ use MooseX::StrictConstructor;
 use Try::Tiny;
 
 use WTSI::DNAP::Utilities::Params qw[function_params];
-use WTSI::NPG::HTS::BatchPublisher;
+use WTSI::NPG::HTS::BatchPublisherFactory;
 use WTSI::NPG::HTS::Illumina::DataObjectFactory;
 use WTSI::NPG::HTS::LIMSFactory;
 use WTSI::NPG::HTS::Seqchksum;
@@ -1392,17 +1392,16 @@ sub _build_batch_publisher {
   my @init_args = (force              => $self->force,
                    irods              => $self->irods,
                    obj_factory        => $self->obj_factory,
-                   state_file         => $self->restart_file,
+                   restart_file       => $self->restart_file,
                    enable_rmq         => $self->enable_rmq,
                    channel            => $self->channel,
                    exchange           => $self->exchange,
-                   routing_key_prefix => $self->routing_key_prefix,
-               );
+                   routing_key_prefix => $self->routing_key_prefix);
   if ($self->has_max_errors) {
     push @init_args, max_errors => $self->max_errors;
   }
-
-  return WTSI::NPG::HTS::BatchPublisher->new(@init_args);
+  my $factory = WTSI::NPG::HTS::BatchPublisherFactory->new(@init_args);
+  return $factory->make_batch_publisher();
 }
 
 sub _build_restart_file {
@@ -1642,7 +1641,7 @@ Keith James <kdj@sanger.ac.uk>, Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2015, 2016, 2017 Genome Research Limited. All Rights
+Copyright (C) 2015, 2016, 2017, 2018 Genome Research Limited. All Rights
 Reserved.
 
 This program is free software: you can redistribute it and/or modify

--- a/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
@@ -25,6 +25,7 @@ with qw[
          WTSI::DNAP::Utilities::JSONCodec
          WTSI::NPG::HTS::PathLister
          WTSI::NPG::HTS::Illumina::Annotator
+         WTSI::NPG::iRODS::Reportable::ConfigurableForRabbitMQ
          npg_tracking::illumina::run::short_info
          npg_tracking::illumina::run::folder
        ];
@@ -1388,12 +1389,17 @@ sub _build_obj_factory {
 sub _build_batch_publisher {
   my ($self) = @_;
 
-  my @init_args = (force       => $self->force,
-                   irods       => $self->irods,
-                   obj_factory => $self->obj_factory,
-                   state_file  => $self->restart_file);
+  my @init_args = (force              => $self->force,
+                   irods              => $self->irods,
+                   obj_factory        => $self->obj_factory,
+                   state_file         => $self->restart_file,
+                   enable_rmq         => $self->enable_rmq,
+                   channel            => $self->channel,
+                   exchange           => $self->exchange,
+                   routing_key_prefix => $self->routing_key_prefix,
+               );
   if ($self->has_max_errors) {
-    push @init_args, max_errors  => $self->max_errors;
+    push @init_args, max_errors => $self->max_errors;
   }
 
   return WTSI::NPG::HTS::BatchPublisher->new(@init_args);
@@ -1632,7 +1638,7 @@ collection, the following take place:
 
 =head1 AUTHOR
 
-Keith James <kdj@sanger.ac.uk>
+Keith James <kdj@sanger.ac.uk>, Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 

--- a/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
@@ -11,7 +11,7 @@ use MooseX::StrictConstructor;
 use Try::Tiny;
 
 use WTSI::DNAP::Utilities::Params qw[function_params];
-use WTSI::NPG::HTS::BatchPublisher;
+use WTSI::NPG::HTS::BatchPublisherFactory;
 use WTSI::NPG::HTS::PacBio::DataObjectFactory;
 use WTSI::NPG::HTS::PacBio::MetaXMLParser;
 use WTSI::NPG::iRODS::Metadata;
@@ -530,16 +530,18 @@ sub _build_dest_collection  {
 sub _build_batch_publisher {
   my ($self) = @_;
 
-  return WTSI::NPG::HTS::BatchPublisher->new
+  my $factory = WTSI::NPG::HTS::BatchPublisherFactory->new
     (force                  => $self->force,
      irods                  => $self->irods,
      obj_factory            => $self->obj_factory,
-     state_file             => $self->restart_file,
+     restart_file           => $self->restart_file,
      enable_rmq             => $self->enable_rmq,
      channel                => $self->channel,
      exchange               => $self->exchange,
      routing_key_prefix     => $self->routing_key_prefix,
      require_checksum_cache => []); ## no md5s precreated for PacBio
+
+  return $factory->make_batch_publisher();
 }
 
 sub _build_restart_file {
@@ -627,10 +629,11 @@ collection, the following take place:
 
 Guoying Qi E<lt>gq1@sanger.ac.ukE<gt>
 Keith James E<lt>kdj@sanger.ac.ukE<gt>
+Iain Bancarz E<lt>ib5@sanger.ac.ukE<gt>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2011, 2016, 2017 Genome Research Limited. All Rights
+Copyright (C) 2011, 2016, 2017, 2018 Genome Research Limited. All Rights
 Reserved.
 
 This program is free software: you can redistribute it and/or modify

--- a/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
@@ -15,7 +15,6 @@ use WTSI::NPG::HTS::BatchPublisher;
 use WTSI::NPG::HTS::PacBio::DataObjectFactory;
 use WTSI::NPG::HTS::PacBio::MetaXMLParser;
 use WTSI::NPG::iRODS::Metadata;
-use WTSI::NPG::iRODS::Publisher;
 use WTSI::NPG::iRODS;
 
 with qw[
@@ -23,6 +22,7 @@ with qw[
          WTSI::NPG::HTS::PathLister
          WTSI::NPG::HTS::PacBio::Annotator
          WTSI::NPG::HTS::PacBio::MetaQuery
+         WTSI::NPG::iRODS::Reportable::ConfigurableForRabbitMQ
        ];
 
 our $VERSION = '';
@@ -535,6 +535,10 @@ sub _build_batch_publisher {
      irods                  => $self->irods,
      obj_factory            => $self->obj_factory,
      state_file             => $self->restart_file,
+     enable_rmq             => $self->enable_rmq,
+     channel                => $self->channel,
+     exchange               => $self->exchange,
+     routing_key_prefix     => $self->routing_key_prefix,
      require_checksum_cache => []); ## no md5s precreated for PacBio
 }
 

--- a/t/batch_publisher_factory.t
+++ b/t/batch_publisher_factory.t
@@ -1,0 +1,8 @@
+
+use strict;
+use warnings;
+
+use WTSI::NPG::HTS::BatchPublisherFactoryTest;
+
+WTSI::NPG::HTS::BatchPublisherFactoryTest->runtests;
+

--- a/t/lib/WTSI/NPG/HTS/BatchPublisherFactoryTest.pm
+++ b/t/lib/WTSI/NPG/HTS/BatchPublisherFactoryTest.pm
@@ -1,0 +1,60 @@
+package WTSI::NPG::HTS::BatchPublisherFactoryTest;
+
+use strict;
+use warnings;
+use File::Temp qw[tempdir];
+use Log::Log4perl;
+
+use Test::More;
+use Test::Exception;
+use WTSI::NPG::iRODS;
+use WTSI::NPG::HTS::BatchPublisherFactory;
+
+use base qw[WTSI::NPG::HTS::TestRabbitMQ];
+
+# Tests below do not require a RabbitMQ server, but *do* require the
+# Net::AMQP::RabbitMQ module. The TEST_RABBITMQ variable defined in the
+# base class WTSI::NPG::HTS::TestRabbitMQ can be used to skip this class,
+# if Net::AMQP::RabbitMQ is not installed.
+
+Log::Log4perl::init('./etc/log4perl_tests.conf');
+
+sub require : Test(1) {
+    require_ok('WTSI::NPG::HTS::BatchPublisherFactory');
+}
+
+sub make_publishers : Test(6) {
+
+    my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
+                                      strict_baton_version => 0);
+
+    my $tmp = tempdir('BatchPublisherFactoryTest_temp_XXXXXX',
+                      CLEANUP => 1);
+
+    my $factory0 = WTSI::NPG::HTS::BatchPublisherFactory->new(
+        enable_rmq         => 0,
+        irods              => $irods,
+        restart_file       => "$tmp/restart.json",
+    );
+    my $publisher0 = $factory0->make_batch_publisher();
+    isa_ok($publisher0, 'WTSI::NPG::HTS::BatchPublisher');
+    # ensure we have an instance of the parent class, not the subclass
+    ok(!($publisher0->isa('WTSI::NPG::HTS::BatchPublisherWithReporting')),
+       'Factory does not return a BatchPublisherWithReporting');
+
+    my $factory1 = WTSI::NPG::HTS::BatchPublisherFactory->new(
+        channel            => 42,
+        enable_rmq         => 1,
+        exchange           => 'foo',
+        irods              => $irods,
+        routing_key_prefix => 'bar',
+        restart_file       => "$tmp/restart.json",
+    );
+    my $publisher1 = $factory1->make_batch_publisher();
+    isa_ok($publisher1, 'WTSI::NPG::HTS::BatchPublisherWithReporting');
+    is($publisher1->channel, 42, 'channel attribute is correct');
+    is($publisher1->exchange, 'foo', 'exchange attribute is correct');
+    is($publisher1->routing_key_prefix, 'bar',
+       'routing_key_prefix attribute is correct');
+
+}

--- a/t/lib/WTSI/NPG/HTS/TestRabbitMQ.pm
+++ b/t/lib/WTSI/NPG/HTS/TestRabbitMQ.pm
@@ -1,0 +1,47 @@
+package WTSI::NPG::HTS::TestRabbitMQ;
+
+use strict;
+use warnings;
+
+use base qw[WTSI::NPG::HTS::Test];
+use Test::More;
+
+# Run full tests (requiring the Net::AMQP::RabbitMQ module) only if
+# specified by environment variables:
+#
+# - If TEST_RABBITMQ is set to a false value, skip RabbitMQ tests.
+#
+# - If TEST_RABBITMQ is not set, fall back to TEST_AUTHOR. Run RabbitMQ
+# tests if TEST_AUTHOR is true; skip tests if it is false or undefined.
+#
+# Typical use case: TEST_AUTHOR is true, to enable testing; then default
+# behaviour is to run RabbitMQ tests as well, unless explicitly
+# cancelled by setting TEST_RABBITMQ to false.
+#
+# This class should be used as the base for any test which uses the
+# WTSI::NPG::HTS::BatchPublisher class.
+
+
+sub runtests {
+    my ($self) = @_;
+    my $run_tests;
+    my $skip_msg; # message to print if skipping tests
+    if (! defined $ENV{TEST_RABBITMQ}) {
+        $run_tests = $ENV{TEST_AUTHOR};
+        $skip_msg = 'TEST_RABBITMQ environment variable not set; '.
+            'TEST_AUTHOR false or not set'
+    } else {
+        $run_tests = $ENV{TEST_RABBITMQ};
+        $skip_msg = 'TEST_RABBITMQ environment variable is false';
+    }
+    if (! $run_tests) {
+        diag('Omitting test class: Either TEST_RABBITMQ ',
+             'is set to false; or TEST_RABBITMQ is not set, and TEST_AUTHOR ',
+             'is false or not set');
+        $self->SKIP_CLASS($skip_msg);
+    }
+    return $self->SUPER::runtests;
+}
+
+
+1;


### PR DESCRIPTION
- Depends on in-progress changes to perl-irods-wrap: https://github.com/wtsi-npg/perl-irods-wrap/pull/163
- Scripts have options to explicitly enable/disable RabbitMQ, and input parameters
- Publisher classes consume the ConfigurableForRabbitMQ role; use PublisherFactory to create a PublisherWithReporting or Publisher, with or without RMQ respectively
- Tests passing with appropriate version of perl-irods-wrap
- Supersedes https://github.com/wtsi-npg/npg_irods/pull/163