### PR TITLE
Extended log publisher find command to inlude STAR aligner log files

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
+
+ - Extended log publisher find command to inlude STAR aligner log files 
+
 Release 2.5
+
  - Refactored BioNano publication, with metadata from MLWH
  - Add file type option in PacBio meta updater
  - Added a configurable local output directory

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -92,7 +92,7 @@ sub publish_logs {
   my $find_p4 =
      q[find . -type f ] .
      q[-a \\( -path "*/tmp_[0-9]*" -a -prune \\) ] .
-     q[-a \\( -name "*.err" -o -name "*.log" -o -name "*.json" \\)];
+     q[-a \\( -name "*.err" -o -name "*.log" -o -name "*.json" -o -name "*_Log*out" \\)];
 
   # find links
   my $find_llist = q[find . -type l];


### PR DESCRIPTION
We are still using the old log publisher. This change is copied from a recent commit to the old publisher.