### PR TITLE
Single server mode

### DIFF
--- a/BuildONT.PL
+++ b/BuildONT.PL
@@ -40,7 +40,7 @@ my $build = BuildONT->new
                          'Try::Tiny'                     => '>= 0.22',
                          'URI'                           => '>= 1.67',
                          'WTSI::DNAP::Utilities'         => 0,
-                         'WTSI::NPG::iRODS'              => '>= 2.8.0'
+                         'WTSI::NPG::iRODS'              => '>= 3.0.2'
                         },
    recommends        => {
                          'UUID' => '>= 0.24',

--- a/lib/WTSI/NPG/HTS/ONT/GridIONRunMonitor.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONRunMonitor.pm
@@ -176,32 +176,37 @@ sub start {
                                            $log_level);
           Log::Log4perl::init(\$logconf);
 
-          my ($expt_name, $device_id) = $self->_parse_device_dir($device_dir);
-          my $output_dir = catdir($self->output_dir, $expt_name, $device_id);
-          make_path($output_dir);
+          try {
+            my ($expt_name, $device_id) = $self->_parse_device_dir($device_dir);
+            my $output_dir = catdir($self->output_dir, $expt_name, $device_id);
+            make_path($output_dir);
 
-          my $publisher = WTSI::NPG::HTS::ONT::GridIONRunPublisher->new
-            (arch_bytes      => $self->arch_bytes,
-             arch_capacity   => $self->arch_capacity,
-             arch_duration   => $self->arch_duration,
-             arch_timeout    => $self->arch_timeout,
-             dest_collection => $self->dest_collection,
-             device_id       => $device_id,
-             experiment_name => $expt_name,
-             f5_uncompress   => 0,
-             output_dir      => $output_dir,
-             source_dir      => $device_dir,
-             session_timeout => $self->session_timeout,
-             tmpdir          => $self->tmpdir);
+            my $publisher = WTSI::NPG::HTS::ONT::GridIONRunPublisher->new
+              (arch_bytes      => $self->arch_bytes,
+               arch_capacity   => $self->arch_capacity,
+               arch_duration   => $self->arch_duration,
+               arch_timeout    => $self->arch_timeout,
+               dest_collection => $self->dest_collection,
+               device_id       => $device_id,
+               experiment_name => $expt_name,
+               f5_uncompress   => 0,
+               output_dir      => $output_dir,
+               source_dir      => $device_dir,
+               session_timeout => $self->session_timeout,
+               tmpdir          => $self->tmpdir);
 
-          my ($nf, $np, $ne) = $publisher->publish_files;
-          $self->debug("GridIONRunPublisher returned [$nf, $np, $ne]");
+            my ($nf, $np, $ne) = $publisher->publish_files;
+            $self->debug("GridIONRunPublisher returned [$nf, $np, $ne]");
 
-          my $exit_code = $ne == 0 ? 0 : 1;
-          $self->info("Finished publishing $nf files from '$device_dir' ",
-                      "with $ne errors and exit code $exit_code");
+            my $exit_code = $ne == 0 ? 0 : 1;
+            $self->info("Finished publishing $nf files from '$device_dir' ",
+                        "with $ne errors and exit code $exit_code");
 
-          $pm->finish($exit_code);
+            $pm->finish($exit_code);
+          } catch {
+            $self->error($_);
+            $pm->finish(1);
+          };
         }
       }
       else {

--- a/lib/WTSI/NPG/HTS/ONT/GridIONRunMonitor.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONRunMonitor.pm
@@ -7,8 +7,6 @@ use Data::Dump q[pp];
 use English qw[-no_match_vars];
 use File::Path qw[make_path];
 use File::Spec::Functions qw[catdir catfile rel2abs splitdir];
-use IO::Select;
-use Linux::Inotify2;
 use Moose;
 use MooseX::StrictConstructor;
 use Parallel::ForkManager;
@@ -21,15 +19,17 @@ with qw[
          WTSI::DNAP::Utilities::Loggable
          WTSI::NPG::iRODS::Utilities
          WTSI::NPG::HTS::ArchiveSession
-         WTSI::NPG::HTS::ONT::Watcher
        ];
 
 our $VERSION = '';
 
-our $SELECT_TIMEOUT   = 2;
 our $ISO8601_DATETIME = '%Y-%m-%dT%H%m%S';
 
-our $EVENTS = IN_MOVED_TO | IN_CREATE | IN_MOVED_FROM | IN_DELETE | IN_ATTRIB;
+## no critic (ValuesAndExpressions::ProhibitMagicNumbers)
+our $SECONDS_PER_MINUTE = 60;
+our $MINUTES_PER_HOUR   = 60;
+our $HOURS_PER_DAY      = 24;
+## use critic
 
 # GridION device directory names match this pattern
 our $DEVICE_DIR_REGEX = qr{^GA\d+}msx;
@@ -58,13 +58,21 @@ has 'dest_collection' =>
    required      => 1,
    documentation => 'The destination collection within iRODS to store data');
 
-has 'device_dir_queue' =>
-  (isa           => 'ArrayRef',
+has 'devices_active' =>
+  (isa           => 'HashRef',
    is            => 'ro',
    required      => 1,
-   default       => sub { return [] },
-   init_arg      => undef,
-   documentation => 'A queue of device directories to be processed');
+   default       => sub { return {} },
+   documentation => 'A map of absolute device directory to publisher PID ' .
+                    'for active devices');
+
+has 'devices_complete' =>
+  (isa           => 'HashRef',
+   is            => 'ro',
+   required      => 1,
+   default       => sub { return {} },
+   documentation => 'A map of absolute device directory to publisher ' .
+                    'completion epoch time for completed device activity');
 
 has 'max_processes' =>
   (isa           => 'Int',
@@ -89,6 +97,24 @@ has 'output_dir' =>
    documentation => 'A directory path under which publisher logs and ' .
                     'manifests will be written');
 
+has 'poll_interval' =>
+  (isa           => 'Int',
+   is            => 'ro',
+   required      => 1,
+   default       => $SECONDS_PER_MINUTE,
+   documentation => 'The interval in seconds at which to poll the filesystem ' .
+                    'for device directories. Defaults to 60 seconds.');
+
+has 'quiet_interval' =>
+  (isa           => 'Int',
+   is            => 'ro',
+   required      => 1,
+   default       => $SECONDS_PER_MINUTE * $MINUTES_PER_HOUR * $HOURS_PER_DAY,
+   documentation => 'The interval in seconds after successful completion of ' .
+                    'a publisher process during which its device directory ' .
+                    'will not be considered for starting a new publisher. ' .
+                    'Defaults tp 24 hours');
+
 has 'source_dir' =>
   (isa           => 'Str',
    is            => 'ro',
@@ -104,13 +130,6 @@ has 'tmpdir' =>
 
 sub start {
   my ($self) = @_;
-
-  my $select = IO::Select->new;
-  $select->add($self->inotify->fileno);
-  $self->_start_watch_source_dir($EVENTS);
-  $self->_start_watch_expt_dirs($EVENTS);
-
-  my %in_progress; # Map device directory path to PID
 
   $self->info(sprintf
               q[Started GridIONRunMonitor with ] .
@@ -129,104 +148,111 @@ sub start {
   $pm->run_on_start(sub {
                       my ($pid, $name) = @_;
                       $self->debug("Process $name (PID $pid) started");
-                      $in_progress{$name} = $pid;
+                      $self->devices_active->{$name} = $pid;
                     });
   $pm->run_on_finish(sub {
                        my ($pid, $exit_code, $name) = @_;
                        $self->debug("Process $name (PID $pid) completed " .
                                     "with exit code: $exit_code");
-                       delete $in_progress{$name};
+                       if ($exit_code == 0) {
+                         my $now = time;
+                         $self->devices_complete->{$name} = $now;
+                       }
+                       delete ${$self->devices_active}{$name};
                      });
 
-  $pm->run_on_wait(sub { $self->debug('Waiting for a child process...') }, 2);
+  $pm->run_on_wait(sub {
+                     $self->debug('ForkManager waiting for child process...');
+                   }, 2);
 
   my $num_errors = 0;
 
   while ($self->monitor) {
     try {
-      $self->debug('Continue ...');
-      if ($select->can_read($SELECT_TIMEOUT)) {
-        my $n = $self->inotify->poll;
-        $self->debug("$n events");
-      }
+      # Parent process
+      my @device_dirs = $self->_find_device_dirs;
+      $self->debug('Found device directories: ', pp\@device_dirs);
 
-      if (@{$self->device_dir_queue}) {
-        $self->debug(scalar @{$self->device_dir_queue},
-                     ' device dirs in queue');
-
-      EVENT: while (my $device_dir = shift @{$self->device_dir_queue}) {
-          # Parent process
-          my $current_pid = $in_progress{$device_dir};
-          if ($current_pid) {
-            $self->debug("$device_dir is already being monitored by process ",
-                         "with PID $current_pid");
-            next EVENT;
-          }
-
-          my $log_level = Log::Log4perl->get_logger($self->meta->name)->level;
-
-          my $pid = $pm->start($device_dir) and next EVENT;
-
-          # Child process
-          my $child_pid = $PID;
-          $self->info("Started GridIONRunPublisher with PID $child_pid on ",
-                      "'$device_dir'");
-          my $logconf =
-            $self->_make_publisher_logconf($self->output_dir, $child_pid,
-                                           $log_level);
-          Log::Log4perl::init(\$logconf);
-
-          try {
-            my ($expt_name, $device_id) = $self->_parse_device_dir($device_dir);
-            my $output_dir = catdir($self->output_dir, $expt_name, $device_id);
-            make_path($output_dir);
-
-            my $publisher = WTSI::NPG::HTS::ONT::GridIONRunPublisher->new
-              (arch_bytes      => $self->arch_bytes,
-               arch_capacity   => $self->arch_capacity,
-               arch_duration   => $self->arch_duration,
-               arch_timeout    => $self->arch_timeout,
-               dest_collection => $self->dest_collection,
-               device_id       => $device_id,
-               experiment_name => $expt_name,
-               f5_uncompress   => 0,
-               output_dir      => $output_dir,
-               source_dir      => $device_dir,
-               session_timeout => $self->session_timeout,
-               tmpdir          => $self->tmpdir);
-
-            my ($nf, $np, $ne) = $publisher->publish_files;
-            $self->debug("GridIONRunPublisher returned [$nf, $np, $ne]");
-
-            my $exit_code = $ne == 0 ? 0 : 1;
-            $self->info("Finished publishing $nf files from '$device_dir' ",
-                        "with $ne errors and exit code $exit_code");
-
-            $pm->finish($exit_code);
-          } catch {
-            $self->error($_);
-            $pm->finish(1);
-          };
+    DEVICE: foreach my $device_dir ($self->_find_device_dirs) {
+        # It's active, so we need do nothing
+        if (exists ${$self->devices_active}{$device_dir}) {
+          my $current_pid = $self->devices_active->{$device_dir};
+          $self->debug("'$device_dir' is already being monitored by process ",
+                       "with PID $current_pid");
+          next DEVICE;
         }
-      }
-      else {
-        $self->debug("Select timeout ($SELECT_TIMEOUT sec) ...");
-        $self->debug('Running processes with PIDs ', pp($pm->running_procs));
-        $pm->reap_finished_children;
 
-        # Check for any other expt dirs that we missed so far e.g. any
-        # which appeared while watches were in the process of being
-        # set up
-        $self->_start_watch_expt_dirs($EVENTS);
+        # If it's not active, this may be caused by a pause in data
+        # gathering (flow cells remain viable for days and may be
+        # re-started). If the flow cell has been active within the
+        # quiet time window, we do not restart it.
+        if (exists ${$self->devices_complete}{$device_dir}) {
+          my $now            = time;
+          my $completed_time = $self->devices_complete->{$device_dir};
+          my $elapsed        = $now - $completed_time;
+          if ($elapsed <= $self->quiet_interval) {
+            $self->debug("'$device_dir' was completed at $completed_time, ",
+                         "$elapsed seconds ago. Still in quiet interval.")
+          }
+          next DEVICE;
+        }
+
+        my $log_level = Log::Log4perl->get_logger($self->meta->name)->level;
+        my $pid = $pm->start($device_dir) and next DEVICE;
+
+        # Child process
+        my $child_pid = $PID;
+        $self->info("Started GridIONRunPublisher with PID $child_pid on ",
+                    "'$device_dir'");
+        my $logconf =
+          $self->_make_publisher_logconf($self->output_dir, $child_pid,
+                                         $log_level);
+        Log::Log4perl::init(\$logconf);
+
+        try {
+          my ($expt_name, $device_id) = $self->_parse_device_dir($device_dir);
+          my $output_dir = catdir($self->output_dir, $expt_name, $device_id);
+          make_path($output_dir);
+
+          my $publisher = WTSI::NPG::HTS::ONT::GridIONRunPublisher->new
+            (arch_bytes      => $self->arch_bytes,
+             arch_capacity   => $self->arch_capacity,
+             arch_duration   => $self->arch_duration,
+             arch_timeout    => $self->arch_timeout,
+             dest_collection => $self->dest_collection,
+             device_id       => $device_id,
+             experiment_name => $expt_name,
+             f5_uncompress   => 0,
+             output_dir      => $output_dir,
+             source_dir      => $device_dir,
+             session_timeout => $self->session_timeout,
+             tmpdir          => $self->tmpdir);
+
+          my ($nf, $np, $ne) = $publisher->publish_files;
+          $self->debug("GridIONRunPublisher returned [$nf, $np, $ne]");
+
+          my $exit_code = $ne == 0 ? 0 : 1;
+          $self->info("Finished publishing $nf files from '$device_dir' ",
+                      "with $ne errors and exit code $exit_code");
+
+          $pm->finish($exit_code);
+        } catch {
+          $self->error($_);
+          $pm->finish(1);
+        };
       }
+
+      $self->debug('ForkManager PIDs: ', pp($pm->running_procs));
+      $self->debug('In progress: ', pp($self->devices_active));
+      $self->debug('Completed: ', pp($self->devices_complete));
+      $pm->reap_finished_children;
+
+      sleep $self->poll_interval;
     } catch {
       $self->error($_);
       $num_errors++;
     };
-  }
-
-  $self->stop_watches;
-  $select->remove($self->inotify->fileno);
+  } # while monitor
 
   my @running = $pm->running_procs;
   $self->info('Waiting for ', scalar @running, ' running processes: ',
@@ -237,95 +263,24 @@ sub start {
   return $num_errors;
 }
 
-# Start watches on the top level data source directory
-sub _start_watch_source_dir {
-  my ($self, $inotify_events) = @_;
+sub _find_device_dirs {
+  my ($self) = @_;
+
+  my @device_dirs;
 
   my $spath = rel2abs($self->source_dir);
-  my $cb    = $self->_make_callback($inotify_events);
+  foreach my $dir ($self->_find_dirs($spath)) {
+    if ($self->_is_expt_dir($dir)) {
 
-  if (not $self->is_watched($spath)) {
-    $self->start_watch($spath, $inotify_events, $cb);
-  }
-
-  return;
-}
-
-# Start watches on any existing expt dirs
-sub _start_watch_expt_dirs {
-  my ($self, $inotify_events) = @_;
-
-  my $spath = rel2abs($self->source_dir);
-  my $cb    = $self->_make_callback($inotify_events);
-
-  my @expt_dirs = $self->_find_dirs($spath);
-  foreach my $expt_dir (@expt_dirs) {
-    if (not $self->is_watched($expt_dir)) {
-      $self->start_watch($expt_dir, $inotify_events, $cb);
-
-      # Queue any existing device dirs, only when starting to watch
-      my @device_dirs = $self->_find_dirs($expt_dir);
-      foreach my $device_dir (@device_dirs) {
-        push @{$self->device_dir_queue}, $device_dir;
+      foreach my $device_dir ($self->_find_dirs($dir)) {
+        $self->debug("Found device directory '$device_dir'");
+        push @device_dirs, $device_dir;
       }
     }
   }
 
-  return;
+  return @device_dirs;
 }
-
-# Return a callback to be fired each time an experiment directory is
-# added to the source_dir or a device directory is added to an
-# experiment directory. For the former, the callback adds itself as an
-# event handler and for the latter, the callback pushes the event's
-# directory path onto a queue to be handled by the main loop.
-sub _make_callback {
-  my ($self, $events) = @_;
-
-  my $device_dir_queue = $self->device_dir_queue;
-
-  return sub {
-    my $event = shift;
-
-    if ($event->IN_Q_OVERFLOW) {
-      $self->warn('Some events were lost!');
-    }
-
-    if ($event->IN_ISDIR) {
-      my $dir = $event->fullname;
-
-      if ($event->IN_CREATE or $event->IN_MOVED_TO or $event->IN_ATTRIB) {
-        if ($self->_is_expt_dir($dir)) {
-          # Path is an experiment directory; watch it for new device dirs
-          $self->debug("Event on experiment dir '$dir'");
-          my $cb = $self->_make_callback($events);
-          try {
-            $self->start_watch($dir, $events, $cb);
-          } catch {
-            $self->error($_);
-          };
-        }
-        elsif ($self->_is_device_dir($dir)) {
-          # Path is a device directory; add it to the queue, to be
-          # handled in the main loop
-          $self->debug("Event on device dir '$dir'");
-          $self->debug("Event IN_CREATE/IN_MOVED_TO/IN_ATTRIB on '$dir'");
-          push @{$device_dir_queue}, $dir;
-        }
-        else {
-          # Path is something else
-          $self->debug("Ignoring uninteresting directory '$dir'");
-        }
-      }
-
-      # Path was removed from the watched hierarchy
-      if ($event->IN_DELETE or $event->IN_MOVED_FROM) {
-        $self->debug("Event IN_DELETE/IN_MOVED_FROM on '$dir'");
-        $self->stop_watch($dir);
-      }
-    }
-  };
-};
 
 sub _make_publisher_logconf {
   my ($self, $path, $pid, $level) = @_;
@@ -365,7 +320,9 @@ sub _is_expt_dir {
   my $leaf   = pop @elts;
   my $parent = catdir(@elts);
 
-  return $parent eq $self->source_dir;
+  # Ignore the 'workspace' directory which the instrument happens to
+  # create in the source directory.
+  return $parent eq $self->source_dir && $leaf ne 'workspace';
 }
 
 # Return true if the path is a "device" directory
@@ -419,13 +376,17 @@ WTSI::NPG::HTS::ONT::GridIONRunMonitor
 
 =head1 DESCRIPTION
 
-Uses inotify to monitor a staging area for new GridION experiment
-result directories. Launches a
-WTSI::NPG::HTS::ONT::GridIONRunPublisher for each existing device
-directory and for any new device directory created. A
-GridIONRunMonitor does not monitor directories below a device
-directory; that responsibility is delegated to its child
+Polls a staging area for new GridION experiment result
+directories. Launches a WTSI::NPG::HTS::ONT::GridIONRunPublisher for
+each existing device directory and for any new device directory
+created. A GridIONRunMonitor does not monitor directories below a
+device directory; that responsibility is delegated to its child
 processes. Each child process is responsible for one device directory.
+
+The filesystem polling interval is set to 60 seconds by default. Once
+a publisher completes processing a device directory successfully, no
+attempt will be made to process it again for the duration of the quiet
+interval, which defaults to 24 hours.
 
 A GridIONRunMonitor will store data in iRODS beneath one collection:
 
@@ -460,7 +421,7 @@ secondary metadata on all files published and previously published.
 
 4. Future runs
 
-A publisher is started when a ne device directory is created. It will
+A publisher is started when a new device directory is created. It will
 first publish new files as it detects their creation. On exiting it
 will check that all files are published and exit after publishing any
 remainder. It will check and update secondary metadata on all files

--- a/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
@@ -464,8 +464,25 @@ sub _do_publish {
   }
   else {
   CASE: {
+      # Ensure that experiment_name and device_id appear in the
+      # relative path in the temporary workspace and therefore also in
+      # the tar file by removing them from the base used to calculate
+      # the relative path.
+      my @dirs = splitdir($self->source_dir);
+      my $did  = pop @dirs; # device_id
+      my $exp  = pop @dirs; # experiment name
+      my $relative_to = catdir(@dirs);
+      $self->debug("Calculating temporary paths relative to '$relative_to' ",
+                   "experiment_name '$exp', device_id '$did'");
+
+      if (not @dirs) {
+        $self->logcroak('No source_dir root remains after trimming');
+      }
+
       my ($vol, $relative_path, $filename) =
-        splitpath(abs2rel($path, $self->source_dir));
+        splitpath(abs2rel($path, $relative_to));
+      $self->debug("Working on path '$path': relative path is ",
+                   "'$relative_path', file name is '$filename'");
 
       my $tmp_dir  = catdir($self->wdir, $relative_path);
       my $tmp_path = catfile($tmp_dir, $filename);

--- a/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
@@ -236,6 +236,8 @@ sub publish_files {
   # The current loading session.
   my $session_active = time; # Session start
   my $continue       = 1;    # While true, continue loading
+  my $num_files      = 0;
+  my $num_processed  = 0;
   my $num_errors     = 0;    # The number of errors this session
   my $session_closed = 0;
 
@@ -288,7 +290,9 @@ sub publish_files {
   # Tar manifest, sequence_summary_n.txt and configuration.cfg files
   my ($nf, $np, $ne)= $self->_publish_ancillary_files;
   $self->debug("Ancillary file publishing returned [$nf, $np, $ne]");
-  $num_errors += $ne;
+  $num_files     += $nf;
+  $num_processed += $np;
+  $num_errors    += $ne;
 
   # Metadata
   my ($nfa, $npa, $nea) = $self->_add_metadata;
@@ -298,12 +302,13 @@ sub publish_files {
   $self->stop_watches;
   $select->remove($self->inotify->fileno);
 
-  my $num_files = 0;
   if ($self->has_f5_publisher) {
-    $num_files += $self->f5_publisher->tar_count;
+    $num_files     += $self->f5_publisher->tar_count;
+    $num_processed += $num_files;
   }
   if ($self->has_fq_publisher) {
-    $num_files += $self->fq_publisher->tar_count;
+    $num_files     += $self->fq_publisher->tar_count;
+    $num_processed += $num_files;
   }
 
   $self->clear_wdir;

--- a/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
@@ -168,10 +168,13 @@ around BUILDARGS => sub {
     my %args = @args;
 
     my $gridion_name = hostname;
+
     my $run = WTSI::NPG::HTS::ONT::GridIONRun->new
-      (gridion_name => $gridion_name,
-       output_dir   => delete $args{output_dir},
-       source_dir   => delete $args{source_dir});
+      (device_id       => delete $args{device_id},
+       experiment_name => delete $args{experiment_name},
+       gridion_name    => $gridion_name,
+       output_dir      => delete $args{output_dir},
+       source_dir      => delete $args{source_dir});
 
     return $class->$orig(gridion_run => $run, %args);
   }

--- a/t/lib/WTSI/NPG/HTS/ONT/GridIONRunAuditorTest.pm
+++ b/t/lib/WTSI/NPG/HTS/ONT/GridIONRunAuditorTest.pm
@@ -55,9 +55,8 @@ sub audit_files : Test(42) {
   my $tmp_basecalled_dir = "$tmp_dir/basecalled";
   my $tmp_run_dir        = "$tmp_basecalled_dir/$expt_name/$device_id";
 
-  _do_publish_files($expt_name, $device_id,
-                    $data_run_dir, $tmp_run_dir, $tmp_basecalled_dir,
-                    $tmp_output_dir, $irods_tmp_coll);
+  _do_publish_files($expt_name, $device_id, $data_run_dir,
+                    $tmp_run_dir, $tmp_output_dir, $irods_tmp_coll);
 
   my $gridion_name = hostname;
 
@@ -172,8 +171,7 @@ sub audit_files : Test(42) {
 }
 
 sub _do_publish_files {
-  my ($expt_name, $device_id,
-      $data_run_dir, $tmp_run_dir, $tmp_basecalled_dir, $tmp_output_dir,
+  my ($expt_name, $device_id, $data_run_dir, $tmp_run_dir, $tmp_output_dir,
       $dest_coll) = @_;
 
   my $arch_capacity = 6;
@@ -202,7 +200,7 @@ sub _do_publish_files {
        f5_uncompress   => $f5_uncompress,
        output_dir      => $tmp_output_dir,
        session_timeout => 30,
-       source_dir      => $tmp_basecalled_dir);
+       source_dir      => $tmp_run_dir);
 
     my ($num_files, $num_processed, $num_errors) = $pub->publish_files;
 

--- a/t/lib/WTSI/NPG/HTS/ONT/GridIONRunAuditorTest.pm
+++ b/t/lib/WTSI/NPG/HTS/ONT/GridIONRunAuditorTest.pm
@@ -55,7 +55,8 @@ sub audit_files : Test(42) {
   my $tmp_basecalled_dir = "$tmp_dir/basecalled";
   my $tmp_run_dir        = "$tmp_basecalled_dir/$expt_name/$device_id";
 
-  _do_publish_files($data_run_dir, $tmp_run_dir, $tmp_basecalled_dir,
+  _do_publish_files($expt_name, $device_id,
+                    $data_run_dir, $tmp_run_dir, $tmp_basecalled_dir,
                     $tmp_output_dir, $irods_tmp_coll);
 
   my $gridion_name = hostname;
@@ -171,7 +172,8 @@ sub audit_files : Test(42) {
 }
 
 sub _do_publish_files {
-  my ($data_run_dir, $tmp_run_dir, $tmp_basecalled_dir, $tmp_output_dir,
+  my ($expt_name, $device_id,
+      $data_run_dir, $tmp_run_dir, $tmp_basecalled_dir, $tmp_output_dir,
       $dest_coll) = @_;
 
   my $arch_capacity = 6;
@@ -195,6 +197,8 @@ sub _do_publish_files {
        arch_capacity   => $arch_capacity,
        arch_timeout    => 10,
        dest_collection => $dest_coll,
+       device_id       => $device_id,
+       experiment_name => $expt_name,
        f5_uncompress   => $f5_uncompress,
        output_dir      => $tmp_output_dir,
        session_timeout => 30,

--- a/t/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisherTest.pm
@@ -148,7 +148,7 @@ sub _do_publish_files {
        f5_uncompress   => $f5_uncompress,
        output_dir      => $tmp_output_dir,
        session_timeout => 30,
-       source_dir      => $tmp_basecalled_dir);
+       source_dir      => $tmp_run_dir);
 
     my ($num_files, $num_processed, $num_errors) = $pub->publish_files;
 

--- a/t/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisherTest.pm
@@ -143,6 +143,8 @@ sub _do_publish_files {
        arch_capacity   => $arch_capacity,
        arch_timeout    => 10,
        dest_collection => $dest_coll,
+       device_id       => $device_id,
+       experiment_name => $expt_name,
        f5_uncompress   => $f5_uncompress,
        output_dir      => $tmp_output_dir,
        session_timeout => 30,


### PR DESCRIPTION
Adds CLI option to activate single server mode. This will prevent the client accessing iRODS resource
servers directly when `iput`ing large files, at the cost of performance.