### PR TITLE
Single server option

### DIFF
--- a/BuildONT.PL
+++ b/BuildONT.PL
@@ -40,7 +40,7 @@ my $build = BuildONT->new
                          'Try::Tiny'                     => '>= 0.22',
                          'URI'                           => '>= 1.67',
                          'WTSI::DNAP::Utilities'         => 0,
-                         'WTSI::NPG::iRODS'              => '>= 2.8.0'
+                         'WTSI::NPG::iRODS'              => '>= 3.0.2'
                         },
    recommends        => {
                          'UUID' => '>= 0.24',

--- a/bin/npg_gridion_run_monitor.pl
+++ b/bin/npg_gridion_run_monitor.pl
@@ -28,6 +28,7 @@ my $output_dir;
 my $poll_interval   = 60;
 my $quiet_interval  = 60 * 60 * 24;
 my $session_timeout = 60 * 20;
+my $single_server;
 my $staging_dir;
 my $tmpdir          = '/tmp';
 my $verbose;
@@ -44,6 +45,7 @@ GetOptions('collection=s'                      => \$collection,
            'poll-interval|poll_interval=i'     => \$poll_interval,
            'quiet-interval|quiet_interval=i'   => \$quiet_interval,
            'session-timeout|session_timeout=s' => \$session_timeout,
+           'single-server|single_server'       => \$single_server,
            'staging-dir|staging_dir=s'         => \$staging_dir,
            'tar_capacity|tar-capacity=i'       => \$arch_capacity,
            'tar-duration|tar_duration=i'       => \$arch_duration,
@@ -81,6 +83,7 @@ my $monitor = WTSI::NPG::HTS::ONT::GridIONRunMonitor->new
    poll_interval   => $poll_interval,
    quiet_interval  => $quiet_interval,
    session_timeout => $session_timeout,
+   single_server   => $single_server,
    source_dir      => $staging_dir,
    tmpdir          => $tmpdir);
 
@@ -106,8 +109,9 @@ npg_gridion_run_monitor
 
 npg_gridion_run_monitor --collection <path> [--debug] [--logconf <path>]
   --output-dir <path> [--poll-interval <n>] [--quiet-interval <n>]
-  --staging-dir <path> [--tar-capacity <n>] [--tar-timeout <n>]
- [--tmpdir <path>] [--verbose]
+  [--single-server] --staging-dir <path>
+  [--tar-capacity <n>] [--tar-timeout <n>]
+  [--tmpdir <path>] [--verbose]
 
  Options:
    --collection      The root iRODS collection in which to write data,
@@ -131,6 +135,8 @@ npg_gridion_run_monitor --collection <path> [--debug] [--logconf <path>]
    --session_timeout The number of seconds idle time after which a multi-file
                      tar session will be closed. Optional, defaults to 60 * 20
                      seconds.
+   --single-server
+   --single_server   Connect to only one iRODS server.
    --staging-dir
    --staging_dir     The data staging directory path to watch.
    --tar-capacity
@@ -163,7 +169,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2017 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2017, 2018 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/bin/npg_publish_gridion_run.pl
+++ b/bin/npg_publish_gridion_run.pl
@@ -24,6 +24,7 @@ my $collection;
 my $debug;
 my $log4perl_config;
 my $session_timeout = 60 * 20;
+my $single_server;
 my $source_dir;
 my $verbose;
 ##use critic
@@ -36,6 +37,7 @@ GetOptions('collection=s'                      => \$collection,
            },
            'logconf=s'                         => \$log4perl_config,
            'session-timeout|session_timeout=s' => \$session_timeout,
+           'single-server|single_server'       => \$single_server,
            'source_dir|source-dir=s'           => \$source_dir,
            'tar-capacity|tar_capacity=i'       => \$arch_capacity,
            'tar-duration|tar_duration=i'       => \$arch_duration,
@@ -72,6 +74,7 @@ my $publisher = WTSI::NPG::HTS::ONT::GridIONRunPublisher->new
    arch_duration   => $arch_duration,
    arch_timeout    => $arch_timeout,
    dest_collection => $collection,
+   single_server   => $single_server,
    source_dir      => $source_dir,
    session_timeout => 200)->publish_files;
 
@@ -84,7 +87,8 @@ npg_publish_gridion_run
 =head1 SYNOPSIS
 
 npg_publish_gridion_run --collection <path> [--debug] [--logconf <path>]
-  --source-dir <path> [--tar-capacity <n>] [--tar-duration <n>]
+  [--single-server] --source-dir <path>
+  [--tar-capacity <n>] [--tar-duration <n>]
   [--tar-timeout <n>] [--verbose]
 
  Options:
@@ -99,6 +103,8 @@ npg_publish_gridion_run --collection <path> [--debug] [--logconf <path>]
    --session_timeout The number of seconds idle time after which a multi-file
                      tar session will be closed. Optional, defaults to 60 * 20
                      seconds.
+   --single-server
+   --single_server   Connect to only one iRODS server.
    --tar-capacity
    --tar_capacity    The number of read files to be archived per tar file.
                      Optional, defaults to 10,000.
@@ -121,7 +127,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2017 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2017, 2018 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/HTS/ONT/GridIONRunMonitor.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONRunMonitor.pm
@@ -115,6 +115,15 @@ has 'quiet_interval' =>
                     'will not be considered for starting a new publisher. ' .
                     'Defaults tp 24 hours');
 
+has 'single_server' =>
+  (is            => 'ro',
+   isa           => 'Bool',
+   default       => 0,
+   documentation => 'If true, connect ony a single iRODS server by avoiding ' .
+                    'any direct connections to resource servers. This mode ' .
+                    'will be much slower to transfer large files, but does ' .
+                    'not require resource servers to be accessible');
+
 has 'source_dir' =>
   (isa           => 'Str',
    is            => 'ro',
@@ -214,6 +223,9 @@ sub start {
           my $output_dir = catdir($self->output_dir, $expt_name, $device_id);
           make_path($output_dir);
 
+          my $irods = WTSI::NPG::iRODS->new
+            (single_server => $self->single_server);
+
           my $publisher = WTSI::NPG::HTS::ONT::GridIONRunPublisher->new
             (arch_bytes      => $self->arch_bytes,
              arch_capacity   => $self->arch_capacity,
@@ -223,6 +235,7 @@ sub start {
              device_id       => $device_id,
              experiment_name => $expt_name,
              f5_uncompress   => 0,
+             irods           => $irods,
              output_dir      => $output_dir,
              source_dir      => $device_dir,
              session_timeout => $self->session_timeout,
@@ -445,7 +458,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2017 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2017, 2018 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisher.pm
@@ -143,6 +143,15 @@ has 'monitor' =>
                     'A caller may set this to false in order to stop ' .
                     'monitoring and wait for any child processes to finish');
 
+has 'single_server' =>
+  (is            => 'ro',
+   isa           => 'Bool',
+   default       => 0,
+   documentation => 'If true, connect ony a single iRODS server by avoiding ' .
+                    'any direct connections to resource servers. This mode ' .
+                    'will be much slower to transfer large files, but does ' .
+                    'not require resource servers to be accessible');
+
 has 'tmpdir' =>
   (isa           => 'Str',
    is            => 'ro',
@@ -894,7 +903,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2017 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2017, 2018 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/t/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/ONT/GridIONRunPublisherTest.pm
@@ -68,6 +68,22 @@ sub publish_files_move : Test(83) {
                     $expected_num_files, $expected_num_items);
 }
 
+sub publish_files_single_server : Test(83) {
+  my $expected_num_files = {fast5 => 7,
+                            fastq => 1};
+  my $expected_num_items = {fast5 => [6, 6, 6, 6, 6, 6, 4], # total 40
+                            fastq => [2]};
+  my $f5_uncompress = 0;
+  my $arch_capacity ||= 6;
+  my $arch_bytes    ||= 10_000_000;
+  my $single_server = 1;
+
+  _do_publish_files($irods_tmp_coll, 'copy',
+                    $expected_num_files, $expected_num_items,
+                    $f5_uncompress, $arch_capacity, $arch_bytes,
+                    $single_server);
+}
+
 sub publish_files_f5_uncompress : Test(83) {
   my $expected_num_files = {fast5 => 7,
                             fastq => 1};
@@ -106,7 +122,8 @@ sub publish_files_tar_bytes : Test(71) {
 sub _do_publish_files {
   my ($dest_coll, $data_mode,
       $expected_num_files, $expected_num_items,
-      $f5_uncompress, $arch_capacity, $arch_bytes) = @_;
+      $f5_uncompress, $arch_capacity, $arch_bytes,
+      $single_server) = @_;
 
   # File::Copy::copy uses open -> syswrite -> close, so we will get a
   # CLOSE event
@@ -148,6 +165,7 @@ sub _do_publish_files {
        f5_uncompress   => $f5_uncompress,
        output_dir      => $tmp_output_dir,
        session_timeout => 30,
+       single_server   => $single_server,
        source_dir      => $tmp_run_dir);
 
     my ($num_files, $num_processed, $num_errors) = $pub->publish_files;


### PR DESCRIPTION
Adds CLI option to activate single server mode. This will prevent the client accessing iRODS resource
servers directly when iputing large files, at the cost of performance.