### PR TITLE
Replaced RENCI FTP site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
     - SAMTOOLS_VERSION="1.5"
     - HTSLIB_VERSION="1.5"
     - TEARS_VERSION="1.2.3"
-    - DISPOSABLE_IRODS_VERSION="1.2"
-    - RENCI_FTP_URL=ftp://ftp.renci.org
+    - DISPOSABLE_IRODS_VERSION="1.3"
+    - RENCI_FTP_URL=https://dnap.cog.sanger.ac.uk
     - WTSI_NPG_GITHUB_URL=https://github.com/wtsi-npg
 
   matrix:


### PR DESCRIPTION
Don't use RENCI's FTP site because we are experiencing regular timeouts.