### PR TITLE
Switch to disposable-irods 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     - HTSLIB_VERSION="1.5"
     - TEARS_VERSION="1.2.3"
     - DISPOSABLE_IRODS_VERSION="1.3"
-    - RENCI_FTP_URL=https://dnap.cog.sanger.ac.uk
     - WTSI_NPG_GITHUB_URL=https://github.com/wtsi-npg
 
   matrix:


### PR DESCRIPTION
Switch to disposable-irods 1.3 (which by default fetches iRODS packages from Sanger S3) and no longer set the RENCI_FTP_URL environment variable.