### PR TITLE
Allow auditing of older GridION tar files

### DIFF
--- a/bin/npg_audit_gridion_tar.pl
+++ b/bin/npg_audit_gridion_tar.pl
@@ -7,7 +7,9 @@ use FindBin qw[$Bin];
 use lib (-d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib");
 
 use Data::Dump qw[pp];
+use Getopt::Long;
 use Log::Log4perl qw[:levels];
+use Pod::Usage;
 
 use WTSI::NPG::HTS::ONT::GridIONTarAuditor;
 

--- a/lib/WTSI/NPG/HTS/ONT/GridIONTarAuditor.pm
+++ b/lib/WTSI/NPG/HTS/ONT/GridIONTarAuditor.pm
@@ -161,7 +161,7 @@ sub _check_tar_files {
     foreach my $tar_path ($manifest->tar_paths) {
 
       my ($nf, $np, $ne) = $self->_check_tar_contents($manifest, $tar_path);
-      $self->info("Checked $np / $nf files in '$tar_path' with $ne errors");
+      $self->info("Checked [ $np / $nf ] files in '$tar_path' with $ne errors");
       $num_files     += $nf;
       $num_processed += $np;
       $num_errors    += $ne;


### PR DESCRIPTION
Allow auditing of older GridION tar files which used a relative path for tarred files different from the current process.

Improved logging at INFO level (reduced in some cases, increased in
others)

Added missing 'use' statements in driver script.