### PR TITLE
illumina run primary metadata for a composition

### DIFF
--- a/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
@@ -1139,11 +1139,8 @@ sub check_merge_primary_metadata {
 
   deep_observed_vs_expected
     ([$obj->find_in_metadata($POSITION)],
-     [{attribute => $POSITION,
-       value     => 1},
-      {attribute => $POSITION,
-       value     => 2}],
-     'Expected lane AVUs present');
+     [],
+     'Lane AVUs are not present - components belong to different lanes');
 
   foreach my $attr ($ALIGNMENT, $TOTAL_READS, $IS_PAIRED_READ,
                     $SEQCHKSUM, $TARGET) {


### PR DESCRIPTION
We will allow a single id_run, lane and tag_index value for a file. We will not set th emetadata if we have multiple values. A combination of an undefined value and a defined value is not considered as a single value.