### PR TITLE
add id_product metadata attr to primary metadata

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -28,7 +28,8 @@ my $build = Build->new
     'Test::MockObject::Extends'     => 0,
     'Test::More'                    => '>= 0.98',
     'Test::Exception'               => '>= 0.32',
-    'Test::Perl::Critic'            => '>= 1.02'
+    'Test::Perl::Critic'            => '>= 1.02',
+    'npg_tracking::glossary::composition' => 0,
    },
    requires =>
    {

--- a/lib/WTSI/NPG/HTS/Illumina/AgfDataObject.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/AgfDataObject.pm
@@ -25,6 +25,7 @@ sub BUILD {
     $ALT_PROCESS,
     $COMPONENT,
     $COMPOSITION,
+    $ID_PRODUCT,
     $GBS_PLEX_NAME,
     $ID_RUN,
     $POSITION,

--- a/lib/WTSI/NPG/HTS/Illumina/AlnDataObject.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/AlnDataObject.pm
@@ -77,6 +77,7 @@ sub BUILD {
     $ALT_TARGET,
     $COMPONENT,
     $COMPOSITION,
+    $ID_PRODUCT,
     $ID_RUN,
     $IS_PAIRED_READ,
     $POSITION,

--- a/lib/WTSI/NPG/HTS/Illumina/Annotator.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/Annotator.pm
@@ -95,6 +95,7 @@ sub make_composition_metadata {
 
   my @avus;
   push @avus, $self->make_avu($COMPOSITION, $composition->freeze);
+  push @avus, $self->make_avu($ID_PRODUCT, $composition->digest);
   foreach my $component ($composition->components_list) {
     push @avus, $self->make_component_metadata($component);
   }

--- a/t/lib/WTSI/NPG/HTS/Illumina/AgfDataObjectTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/AgfDataObjectTest.pm
@@ -22,6 +22,7 @@ use WTSI::NPG::HTS::Illumina::AgfDataObject;
 use WTSI::NPG::HTS::LIMSFactory;
 use WTSI::NPG::iRODS::Metadata;
 use WTSI::NPG::iRODS;
+use npg_tracking::glossary::composition;
 
 {
   package TestDB;
@@ -205,11 +206,13 @@ sub update_secondary_metadata_tag1_no_spike_human : Test(12) {
     my @expected_groups_before = ($public_group, 'ss_10', 'ss_100');
     my @expected_groups_after  = ('ss_2905');
 
+    my $c_json = '{"components":[{"id_run":17550,"position":8,"tag_index":1}]}';
     my $expected_metadata =
       [{attribute => $COMPONENT,
         value     => '{"id_run":17550,"position":8,"tag_index":1}'},
-       {attribute => $COMPOSITION,
-        value     => '{"components":[{"id_run":17550,"position":8,"tag_index":1}]}'},
+       {attribute => $COMPOSITION,              value     => $c_json},
+       {attribute => $ID_PRODUCT,
+        value => _composition_json2product_id($c_json)},
        {attribute => $LIBRARY_ID,               value => '14727840'},
        {attribute => $LIBRARY_TYPE,             value => 'ChIP-Seq Auto'},
        {attribute => $QC_STATE,                 value => '1'},
@@ -307,6 +310,13 @@ sub _build_initargs {
   push @initargs, subset => $subset if defined $subset;
 
   return @initargs;
+}
+
+sub _composition_json2product_id {
+  my $c_json = shift;
+  my $c_class = 'npg_tracking::glossary::composition::component::illumina';
+  return npg_tracking::glossary::composition->thaw(
+    $c_json, component_class => $c_class)->digest;
 }
 
 1;

--- a/t/lib/WTSI/NPG/HTS/Illumina/AlnDataObjectTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/AlnDataObjectTest.pm
@@ -24,6 +24,7 @@ use WTSI::NPG::HTS::LIMSFactory;
 use WTSI::NPG::HTS::Metadata;
 use WTSI::NPG::iRODS::Metadata;
 use WTSI::NPG::iRODS;
+use npg_tracking::glossary::composition;
 
 {
   package TestDB;
@@ -353,14 +354,17 @@ sub nonconsented_human_access_revoked : Test(6) {
                                       group_prefix         => $group_prefix,
                                       group_filter         => $group_filter,
                                       strict_baton_version => 0);
-
-    my $tag1_expected_meta =
+    
+    my $c_json =
+      '{"components":[{"id_run":7915,"position":5,"subset":"human","tag_index":1}]}';
+    my $tag1_expected_meta = 
       [{attribute => $ALIGNMENT,                value => '1'},
        {attribute => 'alignment_filter',        value => 'human'},
        {attribute => $COMPONENT,                value =>
         '{"id_run":7915,"position":5,"subset":"human","tag_index":1}'},
-       {attribute => $COMPOSITION,              value =>
-        '{"components":[{"id_run":7915,"position":5,"subset":"human","tag_index":1}]}'},
+       {attribute => $COMPOSITION,              value => $c_json},
+       {attribute => $ID_PRODUCT,
+        value => _composition_json2product_id($c_json)},
        {attribute => $ID_RUN,                   value => '7915'},
        {attribute => $IS_PAIRED_READ,           value => '1'},
        {attribute => $POSITION,                 value => '5'},
@@ -516,12 +520,14 @@ sub update_secondary_metadata_tag0_no_spike_bact : Test(12) {
                                       group_filter         => $group_filter,
                                       strict_baton_version => 0,);
 
+    my $c_json = '{"components":[{"id_run":7915,"position":5,"tag_index":0}]}';
     my $tag0_expected_meta =
       [{attribute => $ALIGNMENT,                value => '1'},
        {attribute => $COMPONENT,                value =>
         '{"id_run":7915,"position":5,"tag_index":0}'},
-       {attribute => $COMPOSITION,              value =>
-        '{"components":[{"id_run":7915,"position":5,"tag_index":0}]}'},
+       {attribute => $COMPOSITION,              value => $c_json},
+       {attribute => $ID_PRODUCT,
+	value => _composition_json2product_id($c_json)},
        {attribute => $ID_RUN,                   value => '7915'},
        {attribute => $IS_PAIRED_READ,           value => '1'},
        {attribute => $POSITION,                 value => '5'},
@@ -735,12 +741,14 @@ sub update_secondary_metadata_tag0_spike_bact : Test(12) {
                                       group_filter         => $group_filter,
                                       strict_baton_version => 0,);
 
+    my $c_json = '{"components":[{"id_run":7915,"position":5,"tag_index":0}]}';
     my $tag0_expected_meta =
       [{attribute => $ALIGNMENT,               value => '1'},
        {attribute => $COMPONENT,                value =>
         '{"id_run":7915,"position":5,"tag_index":0}'},
-       {attribute => $COMPOSITION,              value =>
-        '{"components":[{"id_run":7915,"position":5,"tag_index":0}]}'},
+       {attribute => $COMPOSITION,              value =>$c_json},
+       {attribute => $ID_PRODUCT,
+        value => _composition_json2product_id($c_json)},
        {attribute => $ID_RUN,                  value => '7915'},
        {attribute => $IS_PAIRED_READ,          value => '1'},
        {attribute => $POSITION,                value => '5'},
@@ -959,12 +967,14 @@ sub update_secondary_metadata_tag1_no_spike_bact : Test(12) {
                                       group_filter         => $group_filter,
                                       strict_baton_version => 0);
 
+    my $c_json = '{"components":[{"id_run":7915,"position":5,"tag_index":1}]}';
     my $tag1_expected_meta =
       [{attribute => $ALIGNMENT,                value => '1'},
        {attribute => $COMPONENT,                value =>
         '{"id_run":7915,"position":5,"tag_index":1}'},
-       {attribute => $COMPOSITION,              value =>
-        '{"components":[{"id_run":7915,"position":5,"tag_index":1}]}'},
+       {attribute => $COMPOSITION,              value => $c_json},
+       {attribute => $ID_PRODUCT,
+        value => _composition_json2product_id($c_json)},
        {attribute => $ID_RUN,                   value => '7915'},
        {attribute => $IS_PAIRED_READ,           value => '1'},
        {attribute => $POSITION,                 value => '5'},
@@ -1015,12 +1025,14 @@ sub update_secondary_metadata_tag1_spike_bact : Test(12) {
                                       group_filter         => $group_filter,
                                       strict_baton_version => 0);
 
+    my $c_json = '{"components":[{"id_run":7915,"position":5,"tag_index":1}]}';
     my $tag1_expected_meta =
       [{attribute => $ALIGNMENT,                value => '1'},
        {attribute => $COMPONENT,                value =>
         '{"id_run":7915,"position":5,"tag_index":1}'},
-       {attribute => $COMPOSITION,              value =>
-        '{"components":[{"id_run":7915,"position":5,"tag_index":1}]}'},
+       {attribute => $COMPOSITION,              value => $c_json},
+       {attribute => $ID_PRODUCT,
+        value => _composition_json2product_id($c_json)},
        {attribute => $ID_RUN,                   value => '7915'},
        {attribute => $IS_PAIRED_READ,           value => '1'},
        {attribute => $POSITION,                 value => '5'},
@@ -1071,12 +1083,14 @@ sub update_secondary_metadata_tag0_no_spike_human : Test(12) {
                                       group_filter         => $group_filter,
                                       strict_baton_version => 0);
 
+    my $c_json = '{"components":[{"id_run":15440,"position":1,"tag_index":0}]}';
     my $tag0_expected_meta =
       [{attribute => $ALIGNMENT,                value => '1'},
        {attribute => $COMPONENT,                value =>
         '{"id_run":15440,"position":1,"tag_index":0}'},
-       {attribute => $COMPOSITION,              value =>
-        '{"components":[{"id_run":15440,"position":1,"tag_index":0}]}'},
+       {attribute => $COMPOSITION,              value => $c_json},
+       {attribute => $ID_PRODUCT,
+        value => _composition_json2product_id($c_json)},
        {attribute => $ID_RUN,                   value => '15440'},
        {attribute => $IS_PAIRED_READ,           value => '1'},
        {attribute => $POSITION,                 value => '1'},
@@ -1145,12 +1159,14 @@ sub update_secondary_metadata_tag0_spike_human : Test(12) {
                                       group_filter         => $group_filter,
                                       strict_baton_version => 0);
 
+    my $c_json = '{"components":[{"id_run":15440,"position":1,"tag_index":0}]}';
     my $tag0_expected_meta =
       [{attribute => $ALIGNMENT,                value => '1'},
        {attribute => $COMPONENT,                value =>
         '{"id_run":15440,"position":1,"tag_index":0}'},
-       {attribute => $COMPOSITION,              value =>
-        '{"components":[{"id_run":15440,"position":1,"tag_index":0}]}'},
+       {attribute => $COMPOSITION,              value => $c_json},
+       {attribute => $ID_PRODUCT,
+        value => _composition_json2product_id($c_json)},
        {attribute => $ID_RUN,                   value => '15440'},
        {attribute => $IS_PAIRED_READ,           value => '1'},
        {attribute => $POSITION,                 value => '1'},
@@ -1226,12 +1242,14 @@ sub update_secondary_metadata_tag81_no_spike_human : Test(12) {
                                       group_filter         => $group_filter,
                                       strict_baton_version => 0);
 
+    my $c_json = '{"components":[{"id_run":15440,"position":1,"tag_index":81}]}';
     my $tag81_expected_meta =
       [{attribute => $ALIGNMENT,                value => '1'},
        {attribute => $COMPONENT,                value =>
         '{"id_run":15440,"position":1,"tag_index":81}'},
-       {attribute => $COMPOSITION,              value =>
-        '{"components":[{"id_run":15440,"position":1,"tag_index":81}]}'},
+       {attribute => $COMPOSITION,              value => $c_json},
+       {attribute => $ID_PRODUCT,
+        value => _composition_json2product_id($c_json)},
        {attribute => $ID_RUN,                   value => '15440'},
        {attribute => $IS_PAIRED_READ,           value => '1'},
        {attribute => $POSITION,                 value => '1'},
@@ -1282,12 +1300,14 @@ sub update_secondary_metadata_tag81_spike_human : Test(12) {
                                       group_filter         => $group_filter,
                                       strict_baton_version => 0);
 
+    my $c_json = '{"components":[{"id_run":15440,"position":1,"tag_index":81}]}';
     my $tag81_expected_meta =
       [{attribute => $ALIGNMENT,                value => '1'},
        {attribute => $COMPONENT,                value =>
         '{"id_run":15440,"position":1,"tag_index":81}'},
-       {attribute => $COMPOSITION,              value =>
-        '{"components":[{"id_run":15440,"position":1,"tag_index":81}]}'},
+       {attribute => $COMPOSITION,              value => $c_json},
+       {attribute => $ID_PRODUCT,
+        value => _composition_json2product_id($c_json)},
        {attribute => $ID_RUN,                   value => '15440'},
        {attribute => $IS_PAIRED_READ,           value => '1'},
        {attribute => $POSITION,                 value => '1'},
@@ -1398,6 +1418,13 @@ sub _build_initargs {
   push @initargs, subset => $subset if defined $subset;
 
   return @initargs;
+}
+
+sub _composition_json2product_id {
+  my $c_json = shift;
+  my $c_class = 'npg_tracking::glossary::composition::component::illumina';
+  return npg_tracking::glossary::composition->thaw(
+    $c_json, component_class => $c_class)->digest;
 }
 
 1;


### PR DESCRIPTION
depends on https://github.com/wtsi-npg/perl-irods-wrap/pull/181

Loading to dev iRODS - av pair is set for cram files

```
attribute: composition
value: {"components":[{"id_run":27793,"position":1,"tag_index":1}]}
attribute: id_product
value: 813501dca1e742268b4e649dfdfd63b73c726a9f9b24eabe394a4817b55f00de

attribute: composition
value: {"components":[{"id_run":27793,"position":1,"subset":"phix","tag_index":1}]}
attribute: id_product
value: 266da1eb49e5543ce36c68798c2883809af8752d4a53c810d7e262f13c61d538
```

Compare to
```
perl -Mnpg_tracking::glossary::composition -le 'print npg_tracking::glossary::composition->thaw(qq[{"components":[{"id_run":27793,"position":1,"tag_index":1}]}], component_class => "npg_tracking::glossary::composition::component::illumina")->digest'
813501dca1e742268b4e649dfdfd63b73c726a9f9b24eabe394a4817b55f00de

perl -Mnpg_tracking::glossary::composition -le 'print npg_tracking::glossary::composition->thaw(qq[{"components":[{"id_run":27793,"position":1,"subset":"phix","tag_index":1}]}], component_class => "npg_tracking::glossary::composition::component::illumina")->digest'
266da1eb49e5543ce36c68798c2883809af8752d4a53c810d7e262f13c61d538
```

