### PR TITLE
Use an LRU cache to retain lims objects temporarily

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -33,6 +33,7 @@ my $build = Build->new
    },
    requires =>
    {
+    'Cache::LRU'                    => 0,
     'Carp'                          => '>= 1.20',
     'Data::Dump'                    => 0,
     'DateTime'                      => '>= 1.18',

--- a/lib/WTSI/NPG/HTS/LIMSFactory.pm
+++ b/lib/WTSI/NPG/HTS/LIMSFactory.pm
@@ -1,5 +1,6 @@
 package WTSI::NPG::HTS::LIMSFactory;
 
+use Cache::LRU;
 use List::AllUtils qw[any];
 use Moose;
 use MooseX::StrictConstructor;
@@ -27,11 +28,23 @@ has 'driver_type' =>
    documentation => 'The ML warehouse driver type used when obtaining ' .
                     'secondary metadata');
 
+has 'max_lims_cache_size' =>
+    (is            => 'ro',
+     isa           => 'Int',
+     required      => 1,
+     default       => 100,
+     documentation => 'The maximum number of lims objects to cache during ' .
+                      'operation');
+
 has 'lims_cache' =>
   (is            => 'ro',
-   isa           => 'HashRef',
+   isa           => 'Cache::LRU',
    required      => 1,
-   default       => sub { return {} },
+   lazy          => 1,
+   default       => sub {
+     my ($self) = @_;
+     return Cache::LRU->new(size => $self->max_lims_cache_size)
+   },
    documentation => 'Cache of st::api::lims indexed on rpt list',
    init_arg      => undef);
 


### PR DESCRIPTION
Use an LRU cache to retain lims objects temporarily, rather than a naive cache that retains them for the duration of the process. This helps avoid excessive memory use at the expense of potentially re-building some objects.