### PR TITLE
Small change to support traction LIMS

### DIFF
--- a/lib/WTSI/NPG/HTS/PacBio/MetaQuery.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/MetaQuery.pm
@@ -51,8 +51,8 @@ sub find_pacbio_runs {
 
   my $well_label = "$row$col";
 
-  my $query      = {id_pac_bio_run_lims => $run_id,
-                    well_label          => $well_label};
+  my $query      = {pac_bio_run_name => $run_id,
+                    well_label       => $well_label};
 
   if (defined $tag_id){
       $query->{tag_identifier} = $tag_id;
@@ -60,7 +60,7 @@ sub find_pacbio_runs {
 
   my @unique_records = $self->mlwh_schema->resultset('PacBioRun')->search
     ($query,  {prefetch => ['sample', 'study'],
-     group_by => [qw/id_pac_bio_run_lims well_label tag_identifier/]});
+     group_by => [qw/pac_bio_run_name well_label tag_identifier/]});
 
   my $num_records = scalar @unique_records;
   $self->debug("Found $num_records records for PacBio ",

--- a/t/fixtures/ml_warehouse/300-PacBioRun.yml
+++ b/t/fixtures/ml_warehouse/300-PacBioRun.yml
@@ -11,6 +11,7 @@
   pac_bio_library_tube_legacy_id: 15977171
   pac_bio_library_tube_name: DN434306G-A1
   pac_bio_library_tube_uuid: 2442d580-ec65-11e5-8770-68b59976a382
+  pac_bio_run_name: 45137
   pac_bio_run_uuid: 11f01620-f013-11e5-8c4c-68b59976a382
   plate_barcode: DN436096A
   plate_uuid_lims: 31b46920-f013-11e5-a007-68b59976a382
@@ -33,6 +34,7 @@
   pac_bio_library_tube_legacy_id: 15977172
   pac_bio_library_tube_name: DN434306G-B1
   pac_bio_library_tube_uuid: 246578b0-ec65-11e5-8770-68b59976a382
+  pac_bio_run_name: 45137
   pac_bio_run_uuid: 11f01620-f013-11e5-8c4c-68b59976a382
   plate_barcode: DN436096A
   plate_uuid_lims: 31b46920-f013-11e5-a007-68b59976a382
@@ -55,6 +57,7 @@
   pac_bio_library_tube_legacy_id: 15958888
   pac_bio_library_tube_name: DN434137H-A1
   pac_bio_library_tube_uuid: 63d82270-eab4-11e5-9a1f-68b59976a382
+  pac_bio_run_name: 45137
   pac_bio_run_uuid: 11f01620-f013-11e5-8c4c-68b59976a382
   plate_barcode: DN436096A
   plate_uuid_lims: 31b46920-f013-11e5-a007-68b59976a382
@@ -77,6 +80,7 @@
   pac_bio_library_tube_legacy_id: 15976081
   pac_bio_library_tube_name: DN434932D-A2
   pac_bio_library_tube_uuid: d904d6e0-ec50-11e5-8770-68b59976a382
+  pac_bio_run_name: 45137
   pac_bio_run_uuid: 11f01620-f013-11e5-8c4c-68b59976a382
   plate_barcode: DN436096A
   plate_uuid_lims: 31b46920-f013-11e5-a007-68b59976a382
@@ -99,6 +103,7 @@
   pac_bio_library_tube_legacy_id: 15976082
   pac_bio_library_tube_name: DN434932D-B2
   pac_bio_library_tube_uuid: d90af160-ec50-11e5-8770-68b59976a382
+  pac_bio_run_name: 45137
   pac_bio_run_uuid: 11f01620-f013-11e5-8c4c-68b59976a382
   plate_barcode: DN436096A
   plate_uuid_lims: 31b46920-f013-11e5-a007-68b59976a382
@@ -121,6 +126,7 @@
   pac_bio_library_tube_legacy_id: 15976083
   pac_bio_library_tube_name: DN434932D-C2
   pac_bio_library_tube_uuid: d91132f0-ec50-11e5-8770-68b59976a382
+  pac_bio_run_name: 45137
   pac_bio_run_uuid: 11f01620-f013-11e5-8c4c-68b59976a382
   plate_barcode: DN436096A
   plate_uuid_lims: 31b46920-f013-11e5-a007-68b59976a382
@@ -143,6 +149,7 @@
   pac_bio_library_tube_legacy_id: 15976084
   pac_bio_library_tube_name: DN434932D-D2
   pac_bio_library_tube_uuid: d9177480-ec50-11e5-8770-68b59976a382
+  pac_bio_run_name: 45137
   pac_bio_run_uuid: 11f01620-f013-11e5-8c4c-68b59976a382
   plate_barcode: DN436096A
   plate_uuid_lims: 31b46920-f013-11e5-a007-68b59976a382
@@ -165,6 +172,7 @@
   pac_bio_library_tube_legacy_id: 11651816
   pac_bio_library_tube_name: DN362988U-A1
   pac_bio_library_tube_uuid: ba804950-34fc-11e4-93bc-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -187,6 +195,7 @@
   pac_bio_library_tube_legacy_id: 11800135
   pac_bio_library_tube_name: DN365397P-A1
   pac_bio_library_tube_uuid: dd6cf670-3a83-11e4-9c2a-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -209,6 +218,7 @@
   pac_bio_library_tube_legacy_id: 11800135
   pac_bio_library_tube_name: DN365397P-A1
   pac_bio_library_tube_uuid: dd6cf670-3a83-11e4-9c2a-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -231,6 +241,7 @@
   pac_bio_library_tube_legacy_id: 11799643
   pac_bio_library_tube_name: DN361557U-A1
   pac_bio_library_tube_uuid: 8a6f6340-3a83-11e4-ad3f-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -253,6 +264,7 @@
   pac_bio_library_tube_legacy_id: 11799643
   pac_bio_library_tube_name: DN361557U-A1
   pac_bio_library_tube_uuid: 8a6f6340-3a83-11e4-ad3f-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -275,6 +287,7 @@
   pac_bio_library_tube_legacy_id: 11799643
   pac_bio_library_tube_name: DN361557U-A1
   pac_bio_library_tube_uuid: 8a6f6340-3a83-11e4-ad3f-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -297,6 +310,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -319,6 +333,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -341,6 +356,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -363,6 +379,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -385,6 +402,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -407,6 +425,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -429,6 +448,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -451,6 +471,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -473,6 +494,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -495,6 +517,7 @@
   pac_bio_library_tube_legacy_id: 11799745
   pac_bio_library_tube_name: DN362987T-A1
   pac_bio_library_tube_uuid: a82f5ac0-3a83-11e4-896d-68b59976a382
+  pac_bio_run_name: 32669
   pac_bio_run_uuid: 6f133680-60fd-11e4-b294-68b59976a382
   plate_barcode: DN374815N
   plate_uuid_lims: 104e63d0-60fe-11e4-a3f1-68b59976a382
@@ -517,6 +540,7 @@
   pac_bio_library_tube_legacy_id: 9445461
   pac_bio_library_tube_name: DN323980T-B1
   pac_bio_library_tube_uuid: 97f319c0-9584-11e3-8a62-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -539,6 +563,7 @@
   pac_bio_library_tube_legacy_id: 14427602
   pac_bio_library_tube_name: DN407857G-E1
   pac_bio_library_tube_uuid: e00e9b70-2959-11e5-a897-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -561,6 +586,7 @@
   pac_bio_library_tube_legacy_id: 14427603
   pac_bio_library_tube_name: DN407857G-F1
   pac_bio_library_tube_uuid: e01ca530-2959-11e5-a897-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -583,6 +609,7 @@
   pac_bio_library_tube_legacy_id: 9445463
   pac_bio_library_tube_name: DN323980T-C1
   pac_bio_library_tube_uuid: 9809d610-9584-11e3-8a62-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -605,6 +632,7 @@
   pac_bio_library_tube_legacy_id: 14528970
   pac_bio_library_tube_name: DN410794I-E3
   pac_bio_library_tube_uuid: 22c741b0-311b-11e5-b214-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -627,6 +655,7 @@
   pac_bio_library_tube_legacy_id: 9445464
   pac_bio_library_tube_name: DN323980T-D1
   pac_bio_library_tube_uuid: 981520b0-9584-11e3-8a62-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -649,6 +678,7 @@
   pac_bio_library_tube_legacy_id: 14643677
   pac_bio_library_tube_name: DN411853G-A1
   pac_bio_library_tube_uuid: 1854f580-3b7d-11e5-8758-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -671,6 +701,7 @@
   pac_bio_library_tube_legacy_id: 9445465
   pac_bio_library_tube_name: DN323980T-E1
   pac_bio_library_tube_uuid: 98206b50-9584-11e3-8a62-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -693,6 +724,7 @@
   pac_bio_library_tube_legacy_id: 14643678
   pac_bio_library_tube_name: DN411853G-B1
   pac_bio_library_tube_uuid: 187500a0-3b7d-11e5-8758-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -715,6 +747,7 @@
   pac_bio_library_tube_legacy_id: 9445466
   pac_bio_library_tube_name: DN323980T-F1
   pac_bio_library_tube_uuid: 98299310-9584-11e3-8a62-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -737,6 +770,7 @@
   pac_bio_library_tube_legacy_id: 14643679
   pac_bio_library_tube_name: DN411853G-C1
   pac_bio_library_tube_uuid: 187e0150-3b7d-11e5-8758-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -759,6 +793,7 @@
   pac_bio_library_tube_legacy_id: 9445460
   pac_bio_library_tube_name: DN323980T-A2
   pac_bio_library_tube_uuid: 97e78100-9584-11e3-8a62-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -781,6 +816,7 @@
   pac_bio_library_tube_legacy_id: 14643680
   pac_bio_library_tube_name: DN411853G-D1
   pac_bio_library_tube_uuid: 18881370-3b7d-11e5-8758-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -803,6 +839,7 @@
   pac_bio_library_tube_legacy_id: 9445462
   pac_bio_library_tube_name: DN323980T-B2
   pac_bio_library_tube_uuid: 97fe6460-9584-11e3-8a62-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -825,6 +862,7 @@
   pac_bio_library_tube_legacy_id: 14643681
   pac_bio_library_tube_name: DN411853G-E1
   pac_bio_library_tube_uuid: 18930ff0-3b7d-11e5-8758-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -847,6 +885,7 @@
   pac_bio_library_tube_legacy_id: 14427602
   pac_bio_library_tube_name: DN407857G-E1
   pac_bio_library_tube_uuid: e00e9b70-2959-11e5-a897-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -869,6 +908,7 @@
   pac_bio_library_tube_legacy_id: 14427603
   pac_bio_library_tube_name: DN407857G-F1
   pac_bio_library_tube_uuid: e01ca530-2959-11e5-a897-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -891,6 +931,7 @@
   pac_bio_library_tube_legacy_id: 14643682
   pac_bio_library_tube_name: DN411853G-F1
   pac_bio_library_tube_uuid: 189b7460-3b7d-11e5-8758-68b59976a382
+  pac_bio_run_name: 40415
   pac_bio_run_uuid: 89e5c9e0-3cea-11e5-936b-68b59976a382
   plate_barcode: DN413057R
   plate_uuid_lims: 35a2a1e0-3ceb-11e5-8758-68b59976a382
@@ -913,6 +954,7 @@
   pac_bio_library_tube_legacy_id: 14270042
   pac_bio_library_tube_name: DN399792H-A1
   pac_bio_library_tube_uuid: 44bb1f00-1e7c-11e5-93c6-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -935,6 +977,7 @@
   pac_bio_library_tube_legacy_id: 14198957
   pac_bio_library_tube_name: DN404324Q-A1
   pac_bio_library_tube_uuid: 813102d0-1691-11e5-93f3-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -957,6 +1000,7 @@
   pac_bio_library_tube_legacy_id: 14270042
   pac_bio_library_tube_name: DN399792H-A1
   pac_bio_library_tube_uuid: 44bb1f00-1e7c-11e5-93c6-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -979,6 +1023,7 @@
   pac_bio_library_tube_legacy_id: 14295273
   pac_bio_library_tube_name: DN407389W-B1
   pac_bio_library_tube_uuid: fb405970-2002-11e5-93c6-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1001,6 +1046,7 @@
   pac_bio_library_tube_legacy_id: 9445459
   pac_bio_library_tube_name: DN323980T-A1
   pac_bio_library_tube_uuid: 97cea1d0-9584-11e3-8a62-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1023,6 +1069,7 @@
   pac_bio_library_tube_legacy_id: 14295274
   pac_bio_library_tube_name: DN407389W-C1
   pac_bio_library_tube_uuid: fb59add0-2002-11e5-93c6-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1045,6 +1092,7 @@
   pac_bio_library_tube_legacy_id: 9445459
   pac_bio_library_tube_name: DN323980T-A1
   pac_bio_library_tube_uuid: 97cea1d0-9584-11e3-8a62-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1067,6 +1115,7 @@
   pac_bio_library_tube_legacy_id: 14295275
   pac_bio_library_tube_name: DN407389W-D1
   pac_bio_library_tube_uuid: fb709130-2002-11e5-93c6-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1089,6 +1138,7 @@
   pac_bio_library_tube_legacy_id: 14427600
   pac_bio_library_tube_name: DN407857G-B1
   pac_bio_library_tube_uuid: dfe56890-2959-11e5-a897-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1111,6 +1161,7 @@
   pac_bio_library_tube_legacy_id: 14427601
   pac_bio_library_tube_name: DN407857G-C1
   pac_bio_library_tube_uuid: e00091b0-2959-11e5-a897-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1133,6 +1184,7 @@
   pac_bio_library_tube_legacy_id: 14295276
   pac_bio_library_tube_name: DN407389W-E1
   pac_bio_library_tube_uuid: fb874d80-2002-11e5-93c6-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1155,6 +1207,7 @@
   pac_bio_library_tube_legacy_id: 14427602
   pac_bio_library_tube_name: DN407857G-E1
   pac_bio_library_tube_uuid: e00e9b70-2959-11e5-a897-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1177,6 +1230,7 @@
   pac_bio_library_tube_legacy_id: 14427603
   pac_bio_library_tube_name: DN407857G-F1
   pac_bio_library_tube_uuid: e01ca530-2959-11e5-a897-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1199,6 +1253,7 @@
   pac_bio_library_tube_legacy_id: 14295277
   pac_bio_library_tube_name: DN407389W-F1
   pac_bio_library_tube_uuid: fba005a0-2002-11e5-93c6-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1221,6 +1276,7 @@
   pac_bio_library_tube_legacy_id: 14295278
   pac_bio_library_tube_name: DN407389W-G1
   pac_bio_library_tube_uuid: fbb2ca50-2002-11e5-93c6-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1243,6 +1299,7 @@
   pac_bio_library_tube_legacy_id: 11799647
   pac_bio_library_tube_name: DN361557U-E1
   pac_bio_library_tube_uuid: 8ac26540-3a83-11e4-ad3f-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1265,6 +1322,7 @@
   pac_bio_library_tube_legacy_id: 14295279
   pac_bio_library_tube_name: DN407389W-H1
   pac_bio_library_tube_uuid: fbc281c0-2002-11e5-93c6-68b59976a382
+  pac_bio_run_name: 39859
   pac_bio_run_uuid: 04659b10-2c7d-11e5-b214-68b59976a382
   plate_barcode: DN410723Q
   plate_uuid_lims: 99592ac0-2c7d-11e5-a6a1-68b59976a382
@@ -1287,6 +1345,7 @@
   pac_bio_library_tube_legacy_id: 18200561
   pac_bio_library_tube_name: DN468178B-A1
   pac_bio_library_tube_uuid: 87f5c5a0-bc77-11e6-9bff-68b59976a384
+  pac_bio_run_name: 50916
   pac_bio_run_uuid: 4f19b100-bc78-11e6-94ff-68b599768938
   plate_barcode: DN470775M
   plate_uuid_lims: 66bcde90-bc78-11e6-9bff-68b59976a384
@@ -1309,6 +1368,7 @@
   pac_bio_library_tube_legacy_id: 21502617
   pac_bio_library_tube_name: DN505769F-H7
   pac_bio_library_tube_uuid: fa31df7e-4488-11e8-acc1-68b599768938
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1331,6 +1391,7 @@
   pac_bio_library_tube_legacy_id: 21502618
   pac_bio_library_tube_name: DN505769F-A8
   pac_bio_library_tube_uuid: fa4707b4-4488-11e8-acc1-68b599768938
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1353,6 +1414,7 @@
   pac_bio_library_tube_legacy_id: 21502619
   pac_bio_library_tube_name: DN505769F-H10
   pac_bio_library_tube_uuid: fa5bb150-4488-11e8-acc1-68b599768938
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1375,6 +1437,7 @@
   pac_bio_library_tube_legacy_id: 21502516
   pac_bio_library_tube_name: DN505768E-B1
   pac_bio_library_tube_uuid: c9224b26-4488-11e8-aa5e-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1397,6 +1460,7 @@
   pac_bio_library_tube_legacy_id: 21502517
   pac_bio_library_tube_name: DN505768E-C1
   pac_bio_library_tube_uuid: c946a7a0-4488-11e8-aa5e-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1419,6 +1483,7 @@
   pac_bio_library_tube_legacy_id: 21502518
   pac_bio_library_tube_name: DN505768E-H1
   pac_bio_library_tube_uuid: c95b7edc-4488-11e8-aa5e-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1441,6 +1506,7 @@
   pac_bio_library_tube_legacy_id: 21502519
   pac_bio_library_tube_name: DN505768E-B3
   pac_bio_library_tube_uuid: c9705a78-4488-11e8-aa5e-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1463,6 +1529,7 @@
   pac_bio_library_tube_legacy_id: 21503105
   pac_bio_library_tube_name: DN505770V-B3
   pac_bio_library_tube_uuid: 1c29edc4-4489-11e8-84f7-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1485,6 +1552,7 @@
   pac_bio_library_tube_legacy_id: 21503106
   pac_bio_library_tube_name: DN505770V-G2
   pac_bio_library_tube_uuid: 1c3ec3e8-4489-11e8-84f7-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1507,6 +1575,7 @@
   pac_bio_library_tube_legacy_id: 21503107
   pac_bio_library_tube_name: DN505770V-H4
   pac_bio_library_tube_uuid: 1c5da4ca-4489-11e8-84f7-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1529,6 +1598,7 @@
   pac_bio_library_tube_legacy_id: 21503108
   pac_bio_library_tube_name: DN505770V-F3
   pac_bio_library_tube_uuid: 1c725eb0-4489-11e8-84f7-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1551,6 +1621,7 @@
   pac_bio_library_tube_legacy_id: 21503109
   pac_bio_library_tube_name: DN505770V-A7
   pac_bio_library_tube_uuid: 1c8700b8-4489-11e8-84f7-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1573,6 +1644,7 @@
   pac_bio_library_tube_legacy_id: 21503110
   pac_bio_library_tube_name: DN505770V-G5
   pac_bio_library_tube_uuid: 1c9bdbfa-4489-11e8-84f7-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1595,6 +1667,7 @@
   pac_bio_library_tube_legacy_id: 21503208
   pac_bio_library_tube_name: DN518129T-E3
   pac_bio_library_tube_uuid: 4cd8e81c-4489-11e8-aa5e-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1617,6 +1690,7 @@
   pac_bio_library_tube_legacy_id: 21503209
   pac_bio_library_tube_name: DN518129T-F3
   pac_bio_library_tube_uuid: 4ceb6ef6-4489-11e8-aa5e-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1639,6 +1713,7 @@
   pac_bio_library_tube_legacy_id: 21503210
   pac_bio_library_tube_name: DN518129T-A4
   pac_bio_library_tube_uuid: 4cf64420-4489-11e8-aa5e-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1661,6 +1736,7 @@
   pac_bio_library_tube_legacy_id: 21475210
   pac_bio_library_tube_name: DN520158U-A1
   pac_bio_library_tube_uuid: 69a60e88-4223-11e8-91fb-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1683,6 +1759,7 @@
   pac_bio_library_tube_legacy_id: 21475210
   pac_bio_library_tube_name: DN520158U-A1
   pac_bio_library_tube_uuid: 69a60e88-4223-11e8-91fb-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1705,6 +1782,7 @@
   pac_bio_library_tube_legacy_id: 21475210
   pac_bio_library_tube_name: DN520158U-A1
   pac_bio_library_tube_uuid: 69a60e88-4223-11e8-91fb-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1727,6 +1805,7 @@
   pac_bio_library_tube_legacy_id: 21475210
   pac_bio_library_tube_name: DN520158U-A1
   pac_bio_library_tube_uuid: 69a60e88-4223-11e8-91fb-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1749,6 +1828,7 @@
   pac_bio_library_tube_legacy_id: 21475210
   pac_bio_library_tube_name: DN520158U-A1
   pac_bio_library_tube_uuid: 69a60e88-4223-11e8-91fb-68b59976a384
+  pac_bio_run_name: 61123
   pac_bio_run_uuid: 8248f7ac-4499-11e8-8060-68b59976a384
   plate_barcode: DN521486O
   plate_uuid_lims: a7967fc0-4499-11e8-84f7-68b59976a384
@@ -1771,6 +1851,7 @@
   pac_bio_library_tube_legacy_id: 19659637
   pac_bio_library_tube_name: DN489056G-A1
   pac_bio_library_tube_uuid: 195960a4-720f-11e7-a726-68b59976a384
+  pac_bio_run_name: 55639
   pac_bio_run_uuid: 652fc964-72e6-11e7-8504-68b599768938
   plate_barcode: DN493601N
   plate_uuid_lims: b52fb9ec-72e6-11e7-899f-68b59976a384
@@ -1793,6 +1874,7 @@
   pac_bio_library_tube_legacy_id: 19659637
   pac_bio_library_tube_name: DN489056G-A1
   pac_bio_library_tube_uuid: 195960a4-720f-11e7-a726-68b59976a384
+  pac_bio_run_name: 55639
   pac_bio_run_uuid: 652fc964-72e6-11e7-8504-68b599768938
   plate_barcode: DN493601N
   plate_uuid_lims: b52fb9ec-72e6-11e7-899f-68b59976a384


### PR DESCRIPTION
SequenceScape tracked batches will always have the same value in both the id_pac_bio_run_lims and pac_bio_run_name fields in the pac_bio_run table. Future traction LIMS tracked runs will enter the run name used in the pacbio SMRT Link LIMS in the pac_bio_run_name field only (and an internal numerical id in the id_pac_bio_run_lims).