### PR TITLE
Ensure add_object retains current checksum behaviour

### DIFF
--- a/t/lib/WTSI/NPG/Data/ConsentWithdrawnTest.pm
+++ b/t/lib/WTSI/NPG/Data/ConsentWithdrawnTest.pm
@@ -36,7 +36,7 @@ sub setup_test : Test(setup) {
     my $source = "$tdir/$file";
     `touch $source`;
     my $target = "$collection/$file";
-    $irods->add_object($source, $target);
+    $irods->add_object($source, $target, $WTSI::NPG::iRODS::CALC_CHECKSUM);
   }
 }
 

--- a/t/lib/WTSI/NPG/HTS/Illumina/AlnDataObjectTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/AlnDataObjectTest.pm
@@ -473,7 +473,8 @@ sub header : Test(13) {
     }
 
     $irods->add_object("$data_path/$invalid.cram",
-                       "$irods_tmp_coll/$invalid.cram");
+                       "$irods_tmp_coll/$invalid.cram",
+                       $WTSI::NPG::iRODS::CALC_CHECKSUM);
 
     # Ensure that a malformed file raises an exception
     my $obj = WTSI::NPG::HTS::Illumina::AlnDataObject->new

--- a/t/lib/WTSI/NPG/HTS/Illumina/MetaUpdaterTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/MetaUpdaterTest.pm
@@ -86,9 +86,14 @@ sub setup_test : Test(setup) {
 
   $irods->add_collection("$irods_tmp_coll/qc");
   $irods->add_object("$data_path/qc/$data_file.genotype.json",
-                     "$irods_tmp_coll/qc");
-  $irods->add_object("$data_path/$data_file.seqchksum", $irods_tmp_coll);
-  $irods->add_object("$data_path/$data_file.composition.json", $irods_tmp_coll);
+                     "$irods_tmp_coll/qc",
+                     $WTSI::NPG::iRODS::CALC_CHECKSUM);
+  $irods->add_object("$data_path/$data_file.seqchksum",
+                     $irods_tmp_coll,
+                     $WTSI::NPG::iRODS::CALC_CHECKSUM);
+  $irods->add_object("$data_path/$data_file.composition.json",
+                     $irods_tmp_coll,
+                     $WTSI::NPG::iRODS::CALC_CHECKSUM);
 }
 
 sub teardown_test : Test(teardown) {

--- a/t/lib/WTSI/NPG/HTS/ONT/GridIONMetaUpdaterTest.pm
+++ b/t/lib/WTSI/NPG/HTS/ONT/GridIONMetaUpdaterTest.pm
@@ -59,7 +59,9 @@ sub setup_test : Test(setup) {
   $test_counter++;
 
   foreach my $file ($f5_data_file, $fq_data_file) {
-    $irods->add_object("$data_path/$file", "$irods_tmp_coll/$file");
+    $irods->add_object("$data_path/$file",
+                       "$irods_tmp_coll/$file",
+                       $WTSI::NPG::iRODS::CALC_CHECKSUM);
     $irods->add_object_avu("$irods_tmp_coll/$file", 'experiment_name', 2);
     $irods->add_object_avu("$irods_tmp_coll/$file", 'device_id', 'GA10000');
   }

--- a/t/lib/WTSI/NPG/HTS/PacBio/MetaUpdaterTest.pm
+++ b/t/lib/WTSI/NPG/HTS/PacBio/MetaUpdaterTest.pm
@@ -56,7 +56,9 @@ sub setup_test : Test(setup) {
     $irods->add_collection("PacBioMetaUpdaterTest.$pid.$test_counter");
   $test_counter++;
 
-  $irods->add_object("$data_path/$data_file", "$irods_tmp_coll/$data_file");
+  $irods->add_object("$data_path/$data_file",
+                     "$irods_tmp_coll/$data_file",
+                     $WTSI::NPG::iRODS::CALC_CHECKSUM);
   $irods->add_object_avu("$irods_tmp_coll/$data_file", 'run', 45137);
   $irods->add_object_avu("$irods_tmp_coll/$data_file", 'well', 'A01');
 }


### PR DESCRIPTION
A change is being make in perl-irods-wrap >3.5.1 to make checksum
creation behaviour consistent. The new default for add_object is NOT
to create the checksum.

This change uses the optional $WTSI::NPG::iRODS::CALC_CHECKSUM
argument to retain current behaviour. (In fact, not setting this and
defaulting to the new behaviour does not impact on the tests
involved.)