### PR TITLE
Add file filter to TreePublisher

### DIFF
--- a/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
@@ -12,10 +12,8 @@ use MooseX::StrictConstructor;
 use Try::Tiny;
 
 use WTSI::DNAP::Utilities::Params qw[function_params];
-use WTSI::NPG::HTS::BatchPublisher;
 
 use WTSI::NPG::HTS::TreePublisher;
-
 use WTSI::NPG::HTS::Illumina::DataObjectFactory;
 use WTSI::NPG::HTS::Illumina::ResultSet;
 use WTSI::NPG::HTS::PublishState;

--- a/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
@@ -583,9 +583,10 @@ sub _tree_publish_run_level {
      compress_formats  => [$self->compress_suffixes],
      irods             => $self->irods);
 
-  my $tree_publisher = $self->_make_tree_publisher;
-  return $tree_publisher->publish_tree($files, $obj_factory,
-                                       $primary_avus_callback);
+  my $tree_publisher = $self->_make_tree_publisher($obj_factory);
+  return $tree_publisher->publish_tree
+      ($files,
+       primary_cb => $primary_avus_callback);
 }
 
 sub _tree_publish_product_level {
@@ -605,18 +606,20 @@ sub _tree_publish_product_level {
      compress_formats  => [$self->compress_suffixes],
      irods             => $self->irods);
 
-  my $tree_publisher = $self->_make_tree_publisher;
-  return $tree_publisher->publish_tree($files, $obj_factory,
-                                       $primary_avus_callback,
-                                       $secondary_avus_callback);
+  my $tree_publisher = $self->_make_tree_publisher($obj_factory);
+  return $tree_publisher->publish_tree
+      ($files,
+       primary_cb   => $primary_avus_callback,
+       secondary_cb => $secondary_avus_callback);
 }
 
 sub _make_tree_publisher {
-  my ($self) = @_;
+  my ($self, $obj_factory) = @_;
 
   my @init_args = (dest_collection  => $self->publish_collection,
                    force            => $self->force,
                    irods            => $self->irods,
+                   obj_factory      => $obj_factory,
                    publish_state    => $self->publish_state,
                    source_directory => $self->source_directory);
   if ($self->has_max_errors) {

--- a/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
@@ -536,9 +536,9 @@ sub _publish_files {
 
   return $self->batch_publisher->publish_file_batch
     ($files, $dest_coll,
-     $primary_avus_callback,
-     $secondary_avus_callback,
-     $extra_avus_callback);
+     primary_cb   => $primary_avus_callback,
+     secondary_cb => $secondary_avus_callback,
+     extra_cb     => $extra_avus_callback);
 }
 ## use critic
 

--- a/lib/WTSI/NPG/OM/BioNano/Saphyr/RunPublisher.pm
+++ b/lib/WTSI/NPG/OM/BioNano/Saphyr/RunPublisher.pm
@@ -211,9 +211,9 @@ sub _publish_files {
 
   return $self->batch_publisher->publish_file_batch
     ($files, $dest_coll,
-     $primary_avus_callback,
-     $secondary_avus_callback,
-     $extra_avus_callback);
+     primary_cb   => $primary_avus_callback,
+     secondary_cb => $secondary_avus_callback,
+     extra_cb     => $extra_avus_callback);
 }
 ## use critic
 

--- a/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
@@ -36,8 +36,6 @@ my $fixture_path = "t/fixtures";
 my $db_dir       = File::Temp->newdir;
 
 my $wh_schema;
-my $lims_factory;
-
 my $irods_tmp_coll;
 
 sub setup_databases : Test(startup) {
@@ -1270,17 +1268,6 @@ sub calc_lane_alignment_files {
   }
 
   return %position_index;
-}
-
-sub expected_data_objects {
-  my ($dest_collection, $position_index, $position) = @_;
-
-  my @expected_paths = map {
-    catfile($dest_collection, scalar fileparse($_))
-  } @{$position_index->{$position}};
-  @expected_paths = sort @expected_paths;
-
-  return @expected_paths;
 }
 
 sub observed_data_objects {

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -103,6 +103,54 @@ sub publish_tree : Test(58) {
   check_metadata($irods, map { catfile($irods_tmp_coll, $_) } @observed_paths);
 }
 
+sub publish_tree_filter : Test(4) {
+  my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
+                                    strict_baton_version => 0);
+  my $source_path = "$data_path/treepublisher";
+
+  my $pub = WTSI::NPG::HTS::TreePublisher->new
+      (irods            => $irods,
+       source_directory => $source_path,
+       dest_collection  => $irods_tmp_coll);
+
+  my $obj_factory = WTSI::NPG::HTS::DefaultDataObjectFactory->new
+      (irods => $pub->irods);
+
+  my @files = grep { -f } $pub->list_directory($source_path, recurse => 1);
+
+  my ($num_files, $num_processed, $num_errors) =
+      $pub->publish_tree(\@files,
+                        filter => sub {
+                          my ($f) = @_;
+                          my ($n) = $f =~ m{(\d)[.]txt$}; # parse digit
+                          # Return true (i.e. pass/include) for even numbers
+                          return $n % 2 == 0;
+                        });
+
+  my $num_expected = 9;
+  cmp_ok($num_errors,    '==', 0, 'No errors on publishing');
+  cmp_ok($num_files, '==', $num_expected,
+         'Found the expected number of files');
+  cmp_ok($num_processed, '==', $num_expected,
+         'Published the expected number of files');
+
+  my @observed_paths = observed_data_objects($irods, $irods_tmp_coll,
+                                             $irods_tmp_coll);
+  my @expected_paths =('a/x/2.txt',
+                       'a/y/4.txt',
+                       'a/z/6.txt',
+                       'b/x/2.txt',
+                       'b/y/4.txt',
+                       'b/z/6.txt',
+                       'c/x/2.txt',
+                       'c/y/4.txt',
+                       'c/z/6.txt');
+
+  is_deeply(\@observed_paths, \@expected_paths,
+            'Published correctly filtered files') or
+      diag explain \@observed_paths;
+}
+
 sub observed_data_objects {
   my ($irods, $dest_collection, $root_collection) = @_;
 

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -63,8 +63,10 @@ sub publish_tree : Test(58) {
   };
 
   my ($num_files, $num_processed, $num_errors) =
-    $pub->publish_tree(\@files, $obj_factory, $primary_avus,
-                       $secondary_avus, $extra_avus);
+      $pub->publish_tree(\@files,
+                         primary_cb   => $primary_avus,
+                         secondary_cb => $secondary_avus,
+                         extra_cb     => $extra_avus);
 
   my $num_expected = scalar @files;
   cmp_ok($num_errors,    '==', 0, 'No errors on publishing');
@@ -74,7 +76,7 @@ sub publish_tree : Test(58) {
          'Published the expected number of files');
 
   my @observed_paths = observed_data_objects($irods, $irods_tmp_coll,
-                                       $irods_tmp_coll);
+                                             $irods_tmp_coll);
   my @expected_paths =('a/x/1.txt',
                        'a/x/2.txt',
                        'a/y/3.txt',


### PR DESCRIPTION
Add a filter to TreePublisher to support partial publishing (and logging) in one place.