### PR TITLE
Set Conda channel order with NPG first and conda-forge last

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Upcoming
- -
+
+ - Order Conda channels for tests so that NPG channels have highest priority
+   and conda-forge the lowest.
 
 Release 2.24.0
 

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -21,8 +21,8 @@ echo "conda activate base" >> ~/.bashrc
 . ~/miniconda/etc/profile.d/conda.sh
 conda activate base
 conda config --set auto_update_conda False
-conda config --add channels "$WSI_CONDA_CHANNEL"
-conda config --add channels conda-forge
+conda config --prepend channels "$WSI_CONDA_CHANNEL"
+conda config --append channels conda-forge
 
 conda create -y -n travis
 conda activate travis
@@ -33,22 +33,8 @@ conda install -y samtools
 conda install -y libhts-plugins"$LIBHTS_PLUGINS_VERSION"
 
 mkdir -p ~/.irods
-if [[ "$IRODS_VERSION" =~ 4\.1\.12 ]]
-then
 
-    cat <<EOF > ~/.irods/irods_environment.json
-{
-    "irods_host": "localhost",
-    "irods_port": 1247,
-    "irods_user_name": "irods",
-    "irods_zone_name": "testZone",
-    "irods_home": "/testZone/home/irods",
-    "irods_plugins_home": "$HOME/miniconda/envs/travis/lib/irods/plugins/",
-    "irods_default_resource": "testResc"
-}
-EOF
-else
-    cat <<'EOF' > ~/.irods/irods_environment.json
+cat <<'EOF' > ~/.irods/irods_environment.json
 {
     "irods_host": "localhost",
     "irods_port": 1247,
@@ -58,7 +44,6 @@ else
     "irods_default_resource": "testResc"
 }
 EOF
-fi
 
 # CPAN
 cpanm --quiet --notest Alien::Tidyp # For npg_tracking


### PR DESCRIPTION
Use "conda config --prepend" rather than "conda config --add" because
it makes it clearer that we are prepending.

Put conda-forge last using --append.

Clean up a redundant case for iRODS 4.1.12, which we no longer have on site.