### PR TITLE
Setting object permissions tweak for ConsentWithdrawn

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 Upcoming
+ - set_object_permissions in WTSI::NPG::Data::ConsentWithdrawn updated to use <user>#<zone> rather than <user> only format 
  - Pacbio RSII specific code clear out
 
  - 

--- a/lib/WTSI/NPG/Data/ConsentWithdrawn.pm
+++ b/lib/WTSI/NPG/Data/ConsentWithdrawn.pm
@@ -244,7 +244,8 @@ sub _restrict_permissions {
     my @to_remove = grep { $_->{level} ne $ownp }
                     $self->irods->get_object_permissions($f);
     for my $p (@to_remove) {
-      $self->irods->set_object_permissions($nullp, $p->{owner}, $f);
+        my $owner_zone = join q[#],$p->{owner},$p->{zone};
+        $self->irods->set_object_permissions($nullp, $owner_zone, $f);
     }
   }
 


### PR DESCRIPTION
Some files without sample_consent_withdrawn_email_sent set were failing due to failure to modify the file permissions using the user (group) name only so this was changed to user#zone