### PR TITLE
Disable the samtools CRAM reference cache during tests

### DIFF
--- a/t/lib/WTSI/NPG/HTS/Test.pm
+++ b/t/lib/WTSI/NPG/HTS/Test.pm
@@ -35,6 +35,10 @@ sub runtests {
     }
   }
 
+  # For tests involving samtools, disable the CRAM reference cache
+  # throughout all tests
+  $env_copy{'REF_PATH'} = 'DUMMY_VALUE';
+
   {
     local %ENV = %env_copy;
     return $self->SUPER::runtests;


### PR DESCRIPTION
Only local references should be used. This REF_PATH is set to a dummy
value to prevent samtools trying HTTP connections.