### PR TITLE
Simplify the test environment

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -160,8 +160,6 @@ jobs:
           find ~/.cpanm/work -cmin -1 -name '*.log' -exec tail -n20  {} \;
 
       - name: "Run tests"
-        env:
-          TEST_AUTHOR: 1
         run: |
           conda activate "$CONDA_TEST_ENVIRONMENT"
 
@@ -171,6 +169,5 @@ jobs:
 
           perl Build.PL
 
-          export WTSI_NPG_iRODS_Test_irodsEnvFile=NULL
           export WTSI_NPG_iRODS_Test_IRODS_ENVIRONMENT_FILE="$HOME/.irods/irods_environment.json"
           ./Build test --verbose

--- a/t/lib/WTSI/NPG/HTS/Test.pm
+++ b/t/lib/WTSI/NPG/HTS/Test.pm
@@ -15,25 +15,15 @@ use Test::More;
 sub runtests {
   my ($self) = @_;
 
+  my $default_irods_env = 'IRODS_ENVIRONMENT_FILE';
+  my $test_irods_env = "WTSI_NPG_iRODS_Test_$default_irods_env";
+  defined $ENV{$test_irods_env} or
+    die "iRODS test environment variable $test_irods_env was not set";
+
   my %env_copy = %ENV;
 
-  # iRODS 3.* and iRODS 4.* have different env vars for configuration
-  foreach my $file (qw[irodsEnvFile IRODS_ENVIRONMENT_FILE]) {
-    my $env_file = $ENV{"WTSI_NPG_iRODS_Test_$file"} || q[];
-
-    # Ensure that the iRODS connection details are a nonsense value if
-    # they are not set explicitly via WTSI_NPG_iRODS_Test_*
-    $env_copy{$file} = $env_file || 'DUMMY_VALUE';
-
-    if (not $env_file) {
-      if ($ENV{TEST_AUTHOR}) {
-        die "Environment variable WTSI_NPG_iRODS_Test_$file was not set";
-      }
-      else {
-        $self->SKIP_CLASS('TEST_AUTHOR environment variable is false');
-      }
-    }
-  }
+  # Ensure that the iRODS connection details are set to the test environment
+  $env_copy{$default_irods_env} = $ENV{$test_irods_env};
 
   # For tests involving samtools, disable the CRAM reference cache
   # throughout all tests


### PR DESCRIPTION
Remove the TEST_AUTHOR distinction and always run the iRODS
tests.

This is an iRODS package, so we always want to test using iRODS. iRODS
servers for testing are cheap to create from our container images. We
are the authors, so we always want to run all the tests.

Remove setting the iRODS 3.x environment variable