### PR TITLE
tweaks to subtrack meta updating

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Upcoming
 
+  - Tweaks to ebi meta updater to account for files with no md5 in
+    the subtrack db (now common due to special projects).
+
 Release 2.32.0
  
   - Archive raw pulldown metrics (gatk_collecthsmetrics) txt file from

--- a/bin/npg_update_ebi_metadata.pl
+++ b/bin/npg_update_ebi_metadata.pl
@@ -38,7 +38,7 @@ LOGCONF
 ;
 
 my $begin_date;
-my $collection;
+my $collections = [];
 my $debug;
 my $dry_run = 1;
 my $end_date;
@@ -47,7 +47,7 @@ my $verbose;
 
 GetOptions('begin-date|begin_date=s'   => \$begin_date,
            'debug'                     => \$debug,
-           'collection=s'              => \$collection,
+           'collection=s@'             => \$collections,
            'dry-run|dry_run!'          => \$dry_run,
            'end-date|end_date=s'       => \$end_date,
            'help'                      => sub { pod2usage(-verbose => 2,
@@ -81,7 +81,7 @@ if ($log4perl_config) {
   $log->info("Using log config file '$log4perl_config'");
 }
 
-$collection ||= $DEFAULT_COLLECTION;
+@{$collections} or $collections = [$DEFAULT_COLLECTION];
 
 my $irods;
 if ($dry_run) {
@@ -117,7 +117,7 @@ my $num_updated = 0;
 if (@submitted_files) {
   my $meta_updater = WTSI::NPG::DataSub::MetaUpdater->new(irods => $irods);
   $num_updated =
-    $meta_updater->update_submission_metadata($collection, \@submitted_files);
+    $meta_updater->update_submission_metadata($collections, \@submitted_files);
 }
 
 $log->info("Updated metadata on $num_updated submitted files");
@@ -141,8 +141,8 @@ npg_update_ebi_metadata [--begin-date YYYY-MM-DD] [--collection path]
   --begin_date  Submission update date range to query, beginning. Optional,
                 defaults to 14 days prior to date given as the --end-date
                 argument.
-  --collection  The iRODS collection in which to work. Optional, defaults
-                to '/seq'.
+  --collection  The iRODS collections in which to work - can be given multiple 
+                times. Optional, defaults to '/seq'.
   --debug       Enable debug level logging. Optional, defaults to false.
   --dry-run
   --dry_run     Enable dry-run mode. Propose metadata changes, but do not

--- a/lib/WTSI/NPG/DataSub/SubtrackClient.pm
+++ b/lib/WTSI/NPG/DataSub/SubtrackClient.pm
@@ -95,6 +95,7 @@ sub _do_query {
    JOIN sub_status stat ON (stat.id = sub.id AND stat.is_current = 'Y')
    JOIN files file ON (sub.id = file.sub_id)
    WHERE (stat.status = 'SD' OR stat.status = 'P')
+   AND file.md5 IS NOT NULL
    AND DATE(stat.timestamp) >= ?
    AND DATE(stat.timestamp) <= ?
 SQL

--- a/t/lib/WTSI/NPG/DataSub/MetaUpdaterTest.pm
+++ b/t/lib/WTSI/NPG/DataSub/MetaUpdaterTest.pm
@@ -86,9 +86,9 @@ sub update_submission_metadata : Test(22) {
   my $dbh_valid = _make_mock_dbh(@expected_valid);
   my @files_valid = WTSI::NPG::DataSub::SubtrackClient->new
     (dbh => $dbh_valid)->query_submitted_files;
-
+ 
   # These 3 files should have submission metadata added
-  cmp_ok($meta_updater->update_submission_metadata("$irods_tmp_coll/valid",
+  cmp_ok($meta_updater->update_submission_metadata(["$irods_tmp_coll/valid"],
                                                    \@files_valid),
          '==', 3, "Updated metadata on unambiguous name/MD5 results");
 
@@ -125,7 +125,7 @@ sub update_submission_metadata : Test(22) {
 
   # These files should not have submission metadata added because they
   # are duplicates
-  cmp_ok($meta_updater->update_submission_metadata("$irods_tmp_coll/invalid",
+  cmp_ok($meta_updater->update_submission_metadata(["$irods_tmp_coll/invalid"],
                                                    \@files_invalid),
          '==', 0, "No metadata update on ambiguous name/MD5 results");
 


### PR DESCRIPTION
Many old files in subtrack have no md5 and many Heron files which have been post processed (also many Heron files with md5 but post processed versions not in iRODS) - so some small tweaks to make this code more useable.