### PR TITLE
Avoid nulls in ebi_sub_acc field

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Upcoming
 
   - Tweaks to ebi meta updater to account for files with no md5 in
     the subtrack db (now common due to special projects).
+  - Also avoid nulls in ebi_sub_acc field for ebi meta updates.
 
 Release 2.32.0
  

--- a/lib/WTSI/NPG/DataSub/SubtrackClient.pm
+++ b/lib/WTSI/NPG/DataSub/SubtrackClient.pm
@@ -96,6 +96,7 @@ sub _do_query {
    JOIN files file ON (sub.id = file.sub_id)
    WHERE (stat.status = 'SD' OR stat.status = 'P')
    AND file.md5 IS NOT NULL
+   AND sub.ebi_sub_acc IS NOT NULL
    AND DATE(stat.timestamp) >= ?
    AND DATE(stat.timestamp) <= ?
 SQL


### PR DESCRIPTION
Issue with ebi_sub_acc information missing in some submitted but not public entries.