### PR TITLE
Create mlwh connection and pass it to LIMSFactory on creation in `npg_publish_illumina_run` script.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -102,6 +102,18 @@ jobs:
 
           baton-do --version
 
+      - name: "Configure test Warehouse"
+        run: |
+          mkdir -p "$HOME/.npg"
+          cat <<'EOF' > "$HOME/.npg/WTSI-DNAP-Warehouse-Schema"
+          #!/usr/bin/env perl
+          my $VAR1 = {
+              'live' => {
+              dsn => 'dbi:sqlite:database=test'
+              }
+          };
+          EOF
+
       - name: "Cache Perl"
         id: cache-perl
         uses: actions/cache@v2

--- a/MANIFEST
+++ b/MANIFEST
@@ -16458,6 +16458,7 @@ t/fixtures/npgqc/MqcOutcomeDict.yml
 t/header_parser.t
 t/illumina_meta_updater.t
 t/illumina_run_publisher.t
+t/lims_factory.t
 t/lib/WTSI/DNAP/Utilities/ParamsTest.pm
 t/lib/WTSI/NPG/Data/BamDeletionTest.pm
 t/lib/WTSI/NPG/Data/ConsentWithdrawnTest.pm
@@ -16470,6 +16471,7 @@ t/lib/WTSI/NPG/HTS/Illumina/AncDataObjectTest.pm
 t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
 t/lib/WTSI/NPG/HTS/Illumina/MetaUpdaterTest.pm
 t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
+t/lib/WTSI/NPG/HTS/LIMSFactoryTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/MetaUpdaterTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/RunPublisherTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/SeqDataObjectTest.pm

--- a/bin/npg_publish_illumina_run.pl
+++ b/bin/npg_publish_illumina_run.pl
@@ -98,8 +98,9 @@ if (not defined $source_directory) {
 }
 
 my $irods = WTSI::NPG::iRODS->new;
+my $wh_schema = WTSI::DNAP::Warehouse::Schema->connect();
 
-my @fac_init_args = ();
+my @fac_init_args = ('mlwh_schema' => $wh_schema);
 if ($driver_type) {
   $log->info("Overriding default driver type with '$driver_type'");
   push @fac_init_args, 'driver_type' => $driver_type;

--- a/bin/npg_publish_illumina_run.pl
+++ b/bin/npg_publish_illumina_run.pl
@@ -98,9 +98,17 @@ if (not defined $source_directory) {
 }
 
 my $irods = WTSI::NPG::iRODS->new;
-my $wh_schema = WTSI::DNAP::Warehouse::Schema->connect();
+my $wh_schema;
 
-my @fac_init_args = ('mlwh_schema' => $wh_schema);
+# default driver is ml_warehouse_fc_cache (see WTSI::NPG::HTS::LIMSFactory)
+if (undef $driver_type or $driver_type =~ /^ml_warehouse/xms) {
+  $wh_schema = WTSI::DNAP::Warehouse::Schema->connect();
+}
+my @fac_init_args = ();
+if (defined $wh_schema) {
+  push @fac_init_args, 'mlwh_schema' => $wh_schema;
+}
+
 if ($driver_type) {
   $log->info("Overriding default driver type with '$driver_type'");
   push @fac_init_args, 'driver_type' => $driver_type;

--- a/bin/npg_publish_illumina_run.pl
+++ b/bin/npg_publish_illumina_run.pl
@@ -98,17 +98,8 @@ if (not defined $source_directory) {
 }
 
 my $irods = WTSI::NPG::iRODS->new;
-my $wh_schema;
 
-# default driver is ml_warehouse_fc_cache (see WTSI::NPG::HTS::LIMSFactory)
-if (undef $driver_type or $driver_type =~ /^ml_warehouse/xms) {
-  $wh_schema = WTSI::DNAP::Warehouse::Schema->connect();
-}
 my @fac_init_args = ();
-if (defined $wh_schema) {
-  push @fac_init_args, 'mlwh_schema' => $wh_schema;
-}
-
 if ($driver_type) {
   $log->info("Overriding default driver type with '$driver_type'");
   push @fac_init_args, 'driver_type' => $driver_type;

--- a/lib/WTSI/NPG/HTS/LIMSFactory.pm
+++ b/lib/WTSI/NPG/HTS/LIMSFactory.pm
@@ -8,6 +8,7 @@ use Scalar::Util qw[refaddr];
 
 use npg_tracking::util::types qw[:all];
 use st::api::lims;
+use WTSI::DNAP::Warehouse::Schema;
 
 our $VERSION = '';
 
@@ -76,6 +77,10 @@ sub make_lims {
     return $self->lims_cache->{$rpt};
   }
   else {
+
+    if ( $self->driver_type =~ /^ml_warehouse/xms) {
+      $self->mlwh_schema = WTSI::DNAP::Warehouse::Schema->connect();
+    }
     my @init_args = (driver_type => $self->driver_type,
                      rpt_list    => $rpt);
     if ($self->has_mlwh_schema) {

--- a/lib/WTSI/NPG/HTS/LIMSFactory.pm
+++ b/lib/WTSI/NPG/HTS/LIMSFactory.pm
@@ -19,6 +19,9 @@ has 'mlwh_schema' =>
    isa           => 'WTSI::DNAP::Warehouse::Schema',
    required      => 0,
    predicate     => 'has_mlwh_schema',
+   clearer       => 'clear_mlwh_schema',
+   lazy          => 1,
+   default       => sub {return WTSI::DNAP::Warehouse::Schema->connect();},
    documentation => 'A ML warehouse handle to obtain secondary metadata');
 
 has 'driver_type' =>
@@ -76,25 +79,18 @@ sub make_lims {
     $self->debug("Using cached LIMS for '$rpt'");
     return $self->lims_cache->{$rpt};
   }
-  else {
 
-    if ( $self->driver_type =~ /^ml_warehouse/xms) {
-      $self->mlwh_schema = WTSI::DNAP::Warehouse::Schema->connect();
-    }
-    my @init_args = (driver_type => $self->driver_type,
-                     rpt_list    => $rpt);
-    if ($self->has_mlwh_schema) {
-      push @init_args, mlwh_schema => $self->mlwh_schema;
-    }
-
-    my $lims = st::api::lims->new(@init_args);
-
-    $self->lims_cache->{$rpt} = $lims;
-
-    return $lims;
+  my @init_args = (driver_type => $self->driver_type,
+                   rpt_list    => $rpt);
+  if ($self->driver_type =~ /^ml_warehouse/xms) {
+    push @init_args, mlwh_schema => $self->mlwh_schema;
   }
 
-  return;
+  my $lims = st::api::lims->new(@init_args);
+
+  $self->lims_cache->{$rpt} = $lims;
+
+  return $lims;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/WTSI/NPG/HTS/LIMSFactory.pm
+++ b/lib/WTSI/NPG/HTS/LIMSFactory.pm
@@ -84,12 +84,6 @@ sub make_lims {
 
     my $lims = st::api::lims->new(@init_args);
 
-    # If the st::api::lims provided a database handle itself and the
-    # factory has not, cache the handle.
-    if (not $self->has_mlwh_schema and $lims->can('mlwh_schema')) {
-      $self->mlwh_schema($lims->mlwh_schema);
-    }
-
     $self->lims_cache->{$rpt} = $lims;
 
     return $lims;

--- a/t/lib/WTSI/NPG/HTS/LIMSFactoryTest.pm
+++ b/t/lib/WTSI/NPG/HTS/LIMSFactoryTest.pm
@@ -1,0 +1,66 @@
+package WTSI::NPG::HTS::LIMSFactoryTest;
+
+use strict;
+use warnings;
+
+use English qw[-no_match_vars];
+use Log::Log4perl;
+use Test::More;
+use Test::Exception;
+
+use base qw[WTSI::NPG::HTS::Test];
+
+use npg_tracking::glossary::composition;
+use npg_tracking::glossary::composition::component::illumina;
+use WTSI::NPG::HTS::LIMSFactory;
+
+Log::Log4perl::init('./etc/log4perl_tests.conf');
+
+sub make_composition {
+  my ($id_run, $position) = @_;
+  my $component = npg_tracking::glossary::composition::component::illumina->new(
+    {
+      id_run   => $id_run,
+      position => $position,
+    });
+  return npg_tracking::glossary::composition->new({components => [$component]});
+}
+
+sub make_lims_mlwh_driver : Test(10){
+  my $lims_factory = WTSI::NPG::HTS::LIMSFactory->new(
+    {driver_type => 'ml_warehouse_fc_cache'});
+  my $composition = make_composition(1, 1);
+  my $lims;
+  lives_ok{$lims = $lims_factory->make_lims($composition)}
+    'lims made successfully';
+  my $cached_schema = $lims_factory->{mlwh_schema};
+  is($lims->{_driver_arguments}->{mlwh_schema}, $cached_schema, 'lims uses cached mlwh_schema');
+  is($lims, $lims_factory->{lims_cache}->{$composition->freeze2rpt},
+    'lims in lims cache');
+  my $diff_composition = make_composition(2, 1);
+  my $diff_lims = $lims_factory->make_lims($diff_composition);
+  isnt($diff_lims, $lims, 'lims are not the same');
+  is($diff_lims->{_driver_arguments}->{mlwh_schema}, $cached_schema,
+    'cached schema used for new lims');
+  lives_ok{$lims_factory->clear_mlwh_schema} 'can clear mlwh_schema';
+  is($lims_factory->has_mlwh_schema, '', 'mlwh_schema cleared');
+  my $post_clear_composition = make_composition(1, 2);
+  my $post_clear_lims;
+  lives_ok{$post_clear_lims = $lims_factory->make_lims($post_clear_composition)}
+    'can make a new lims after clearing mlwh_schema';
+  is $lims_factory->has_mlwh_schema, 1, 'new mlwh_schema cached';
+  isnt($post_clear_lims->{_driver_arguments}->{mlwh_schema}, $lims->{mlwh_schema},
+    'new mlwh_schema is different from previous mlwh_schema');
+}
+
+sub make_lims_non_mlwh_driver : Test(2){
+  my $lims_factory = WTSI::NPG::HTS::LIMSFactory->new(
+    {driver_type => 'samplesheet'});
+  my $composition = make_composition(1, 1);
+  my $lims;
+  lives_ok{$lims = $lims_factory->make_lims($composition)}
+    'lims made successfully';
+  is($lims->{_driver_arguments}->{mlwh_schema}, undef, 'no mlwh_schema with non-mlwh driver');
+}
+
+1;

--- a/t/lims_factory.t
+++ b/t/lims_factory.t
@@ -1,0 +1,8 @@
+
+use strict;
+use warnings;
+
+use WTSI::NPG::HTS::LIMSFactoryTest;
+
+WTSI::NPG::HTS::LIMSFactoryTest->runtests;
+


### PR DESCRIPTION
The publisher was previously written to cache an mlwh connection
created by LIMSFactory, but failed to do so, leading to creation of
multiple connections.