### PR TITLE
Tweak Sequel AnalysisPublisher to allow for xml in entry-points subdir

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Upcoming
 
+  - Tweak Sequel AnalysisPublisher for SMRT Link 10.2 to allow xml
+    in entry-points subdir.
 
 Release 2.34.0
 

--- a/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisPublisher.pm
@@ -294,8 +294,9 @@ sub _build_metadata{
 
   my $entry_dir = catdir($self->analysis_path, $ENTRY_DIR);
 
-  my @metafiles = $self->list_directory($entry_dir,
-                                        filter => $METADATA_FORMAT . q[$]);
+  my @metafiles = $self->list_directory
+    ($entry_dir, filter => $METADATA_FORMAT . q[$], recurse => 1);
+
   if (@metafiles != 1) {
     $self->logcroak("Expect one $METADATA_FORMAT file in $entry_dir");
   }


### PR DESCRIPTION
In SMRT Link 10.2 set xml for analysis jobs is now in subdir of entry-points dir.