### PR TITLE
Add single-replica metadata update script

### DIFF
--- a/bin/npg_update_single_replica_metadata.pl
+++ b/bin/npg_update_single_replica_metadata.pl
@@ -1,0 +1,201 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use FindBin qw[$Bin];
+use lib (-d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib");
+
+use DateTime::Format::ISO8601;
+use Getopt::Long;
+use Log::Log4perl qw[:levels];
+use Pod::Usage;
+
+use WTSI::NPG::Data::SingleReplicaMetaUpdater;
+use WTSI::NPG::DriRODS;
+use WTSI::NPG::iRODS;
+
+our $VERSION = '';
+our $DEFAULT_COLLECTION = '/seq';
+
+my $verbose_config = << 'LOGCONF'
+log4perl.logger = ERROR, A1
+
+log4perl.logger.WTSI.NPG.Data.SingleReplicaMetaUpdater = INFO, A1
+
+log4perl.appender.A1 = Log::Log4perl::Appender::Screen
+log4perl.appender.A1.layout = Log::Log4perl::Layout::PatternLayout
+log4perl.appender.A1.layout.ConversionPattern = %d %-5p %c - %m%n
+log4perl.appender.A1.utf8 = 1
+
+# Prevent duplicate messages with a non-Log4j-compliant Log4perl option
+log4perl.oneMessagePerAppender = 1
+LOGCONF
+;
+
+my $begin_date;
+my $debug;
+my $dry_run;
+my $end_date;
+my $log4perl_config;
+my $verbose;
+
+GetOptions('begin-date|begin_date=s' => \$begin_date,
+           'debug'                   => \$debug,
+           'dry-run|dry_run!'        => \$dry_run,
+           'end-date|end_date=s'     => \$end_date,
+           'help'                    => sub { pod2usage(-verbose => 2,
+                                                        -exitval => 0) },
+           'logconf=s'               => \$log4perl_config,
+           'verbose'                 => \$verbose);
+
+# Process CLI arguments
+if ($log4perl_config) {
+  Log::Log4perl::init($log4perl_config);
+}
+else {
+  if ($verbose and not $debug) {
+    Log::Log4perl::init(\$verbose_config);
+  }
+  else {
+    my $level = $debug ? $DEBUG : $WARN;
+    Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+        level  => $level,
+        utf8   => 1});
+  }
+}
+
+my $log = Log::Log4perl->get_logger('main');
+$log->level($ALL);
+
+if ($log4perl_config) {
+  $log->info("Using log config file '$log4perl_config'");
+}
+
+my $irods;
+if ($dry_run) {
+  $irods = WTSI::NPG::DriRODS->new;
+}
+else {
+  $irods = WTSI::NPG::iRODS->new;
+}
+
+my $updater = WTSI::NPG::Data::SingleReplicaMetaUpdater->new(irods => $irods);
+my $grace = DateTime::Duration->new(years => $updater->default_grace_period);
+my $grace_threshold = DateTime->now->subtract($grace);
+
+
+my $begin;
+if (defined $begin_date) {
+  $begin = DateTime::Format::ISO8601->parse_datetime($begin_date);
+}
+else {
+  $begin = DateTime->from_epoch(epoch => 0);
+}
+
+my $end;
+if (defined $end_date) {
+  $end = DateTime::Format::ISO8601->parse_datetime($end_date);
+}
+else {
+  $end = $grace_threshold->clone->subtract(DateTime::Duration->new(days => 1))
+}
+
+if (not DateTime->compare($end, $grace_threshold) < 0) {
+  $log->logcroak(sprintf q[The end date %s is too recent; it must be ] .
+                         q[earlier than the grace period threshold %s],
+                         $end->iso8601, $grace_threshold->iso8601);
+}
+if (not DateTime->compare($begin, $grace_threshold) < 0) {
+  $log->logcroak(sprintf q[The begin date %s is too recent; it must be ] .
+                         q[earlier than the grace period threshold %s],
+                         $begin->iso8601, $grace_threshold->iso8601);
+}
+if (not DateTime->compare($begin, $end) < 0) {
+  $log->logcroak(sprintf q[The begin date %s is too recent; it must be ] .
+                         q[earlier than the end date %s],
+                         $begin->iso8601, $end->iso8601);
+}
+
+$log->info(sprintf q[Updating objects with creation dates between %s ] .
+                   q[and %s], $begin, $end);
+
+my ($num_objects, $num_processed, $num_errors) =
+    $updater->update_single_replica_metadata(begin_date => $begin,
+                                             end_date   => $end);
+
+my $msg = sprintf q[Found %d data objects, processed %d with %d errors],
+                  $num_objects, $num_processed, $num_errors;
+if ($num_errors != 0) {
+  $log->logcroak($msg);
+}
+
+$log->info($msg);
+
+__END__
+
+=head1 NAME
+
+npg_update_single_replica_metadata
+
+=head1 SYNOPSIS
+
+npg_update_single_replica_metadata [--begin-date YYYY-MM-DD] [--debug]
+[--end-date YYYY-MM-DD] [--help] [--logconf file] [--verbose]
+
+ Options:
+
+  --begin-date
+  --begin_date  Earliest creation date of data objects to consider for
+                update. Optional, defaults to the epoch.
+  --debug       Enable debug level logging. Optional, defaults to false.
+  --dry-run
+  --dry_run     Enable dry-run mode. Find eligible data objects and report
+                them, but do not update them. Optional, defaults to false.
+  --end-date
+  --end_date    Latest creation date of data objects to consider for update.
+                Optional, defaults to 1 day earlier than the grace period.
+  --help        Display help.
+  --logconf     A log4perl configuration file. Optional.
+  --verbose     Print messages while processing. Optional.
+
+  The date arguments may be in any format accepted by
+  DateTime::Format::ISO8601 e.g.
+
+    YYYYMMDD
+    YYYY-MM-DD
+    YYYYMMDDThhmm
+    YYYY-MM-DDThh:mm
+
+=head1 DESCRIPTION
+
+This script finds data objects that are eligible for migration to a
+single-replica resource and marks them with metadata that will instruct
+the iRODS server to do that.
+
+Candidate data objects are those that have metadata dcterms:created between
+the begin-date and end date and are not already marked for migration. The
+end date may not be more recent than the current date, minus the grace period.
+
+In dry run mode, the proposed metadata changes will be written as INFO
+notices to the log.
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2022 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/lib/WTSI/NPG/Data/SingleReplicaMetaUpdater.pm
+++ b/lib/WTSI/NPG/Data/SingleReplicaMetaUpdater.pm
@@ -211,7 +211,7 @@ sub _parse_iquest_records {
     # Work around the iquest bug/misfeature where it mixes its logging output
     # with its data output
     next if $line =~ m{^Zone is}msx;
-    next if $line =~ m{^No rows found}msx;
+    next if $line =~ m{^No\s+rows\s+found}msx;
 
     $self->debug("iquest: $line");
     if ($line eq $record_separator and @path_elements) {

--- a/scripts/add_single_replica_query.sh
+++ b/scripts/add_single_replica_query.sh
@@ -7,24 +7,23 @@ QUERY_NAME=find_single_replica_targets
 
 query=$(
 tr '\n' ' ' <<- EOF
-select distinct
-c.coll_name as coll_name,
-d.data_name as data_name
-from r_data_main d join r_coll_main as c on c.coll_id = d.coll_id
-join r_objt_metamap mm1 on d.data_id = mm1.object_id
-join r_meta_main m1 on mm1.meta_id = m1.meta_id
-join r_objt_metamap mm2 on d.data_id = mm2.object_id
-join r_meta_main m2 on mm2.meta_id = m2.meta_id
-where d.data_id not in
-  (select d.data_id from r_data_main d
-   join r_objt_metamap mm on d.data_id = mm.object_id
-   join r_meta_main m on mm.meta_id = m.meta_id
-   where m.meta_attr_name = 'tier:single-copy')
-and m1.meta_attr_name = 'ebi_sub_md5'
-and m2.meta_attr_name = 'dcterms:created'
-and m2.meta_attr_value > ?
-and m2.meta_attr_value < ?
-order by coll_name, data_name
+select distinct c.coll_name, d.data_name
+from r_data_main d, r_coll_main c
+where d.coll_id = c.coll_id
+and d.data_id in
+((select object_id from r_meta_main mm, r_objt_metamap om
+  where mm.meta_id = om.meta_id
+  and mm.meta_attr_name = 'ebi_sub_md5'
+  intersect
+  select object_id from r_meta_main mm, r_objt_metamap om
+  where mm.meta_id = om.meta_id
+  and mm.meta_attr_name = 'dcterms:created'
+  and mm.meta_attr_value > ?
+  and mm.meta_attr_value < ?)
+ except
+ select object_id from r_meta_main mm, r_objt_metamap om
+ where mm.meta_id = om.meta_id
+ and mm.meta_attr_name = 'tier:single-copy')
 EOF
 )
 

--- a/t/lib/WTSI/NPG/Data/SingleReplicaMetaUpdaterTest.pm
+++ b/t/lib/WTSI/NPG/Data/SingleReplicaMetaUpdaterTest.pm
@@ -3,6 +3,7 @@ package WTSI::NPG::Data::SingleReplicaMetaUpdaterTest;
 use strict;
 use warnings;
 
+use Cwd qw[cwd];
 use DateTime;
 use English qw[-no_match_vars];
 use File::Basename;
@@ -19,7 +20,7 @@ Log::Log4perl::init('./etc/log4perl_tests.conf');
 
 my $pid          = $PID;
 my $test_counter = 0;
-my $data_path    = 't/data/single_replica';
+my $data_path    = cwd . q[/] . 't/data/single_replica';
 
 my $irods_tmp_coll;
 

--- a/t/lib/WTSI/NPG/Data/SingleReplicaMetaUpdaterTest.pm
+++ b/t/lib/WTSI/NPG/Data/SingleReplicaMetaUpdaterTest.pm
@@ -42,10 +42,6 @@ sub setup_fixture : Test(startup) {
     (executable => './scripts/add_single_replica_query.sh')->run;
 }
 
-#sub teardown_fixture : Test(shutdown) {
-#
-#}
-
 sub setup_test : Test(setup) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);


### PR DESCRIPTION
This script will be run by cron to do regular updates. It will also serve to mark up a subset of the historical data objects while scaling up in production.