### PR TITLE
Updated the npg_publish_tree client and publish_tree test to write json file

### DIFF
--- a/lib/WTSI/NPG/HTS/TreePublisher.pm
+++ b/lib/WTSI/NPG/HTS/TreePublisher.pm
@@ -80,6 +80,10 @@ has 'require_checksum_cache' =>
                Function returning true for each file path to be published.
                CodeRef. Optional.
 
+               mlwh_json_cb
+               Callback writing metadata of all objects to a JSON file.
+               CodeRef. Optional.
+
   Example    : my ($num_files, $num_processed, $num_errors) =
                  $pub->publish_tree($files,
                                     primary_cb   => sub { ... },


### PR DESCRIPTION
The proposed feature aims to update the tree publisher client to accept a defined callback to write a json file. The file contains information about the data uploaded and the irods top collection folder. Feature #363.