### PR TITLE
Add a method to TreePublisher to write json file and expose it in npg_tree_publisher script

### DIFF
--- a/bin/npg_publish_tree.pl
+++ b/bin/npg_publish_tree.pl
@@ -191,7 +191,7 @@ my @files = grep { -f } $publisher->list_directory($source_directory,
 my $mlwh_json_cb = sub {
   # DataObject, path to file folder, collection file
   my ($obj, $collection, $file) = @_;
-  if (defined $mlwh_json_filename) { 
+  if (defined $mlwh_json_filename) {
     Readonly::Scalar my $JSON_FILE_VERSION => '1.0';
     my $mlwh_hash = {
       irods_root_collection    => $collection,
@@ -210,7 +210,7 @@ my $mlwh_json_cb = sub {
         qq[$mlwh_json_filename]);
       $json_hash = {
         version  => $JSON_FILE_VERSION,
-        irods_top_collection_folder => $irods_tmp_coll,
+        top_collection_folder => $dest_collection,
         products => [],
       };
     }

--- a/lib/WTSI/NPG/HTS/TreePublisher.pm
+++ b/lib/WTSI/NPG/HTS/TreePublisher.pm
@@ -11,6 +11,9 @@ use WTSI::DNAP::Utilities::Params qw[function_params];
 use WTSI::NPG::HTS::BatchPublisher;
 use WTSI::NPG::HTS::PublishState;
 
+use JSON;
+use Readonly;
+
 with qw[
          WTSI::DNAP::Utilities::Loggable
          WTSI::NPG::HTS::RunPublisher
@@ -18,6 +21,7 @@ with qw[
        ];
 
 our $VERSION = '';
+Readonly::Scalar my $JSON_FILE_VERSION => '1.1';
 
 has 'obj_factory' =>
     (does          => 'WTSI::NPG::HTS::DataObjectFactory',
@@ -60,6 +64,13 @@ has 'require_checksum_cache' =>
      documentation => 'A list of file suffixes for which MD5 cache files ' .
                       'must be provided and will not be created on the fly');
 
+has 'mlwh_json' =>
+  (isa           => 'Str',
+  is             => 'ro',
+  required       => 0,
+  documentation  => 'The json file to which information about the irods collection ' .
+                    'folder will be added. Cannot be used with mlwh_json_cb defined.');
+
 =head2 publish_tree
 
   Arg [1]    : File batch, ArrayRef[Str].
@@ -81,8 +92,8 @@ has 'require_checksum_cache' =>
                CodeRef. Optional.
 
                mlwh_json_cb
-               Callback writing metadata of all objects to a JSON file.
-               CodeRef. Optional.
+               Callback writing information of a collection to JSON file.
+               CodeRef. Optional. Cannot be used with mlwh_json attribute set.
 
   Example    : my ($num_files, $num_processed, $num_errors) =
                  $pub->publish_tree($files,
@@ -107,9 +118,32 @@ has 'require_checksum_cache' =>
   my @named      = qw[primary_cb secondary_cb extra_cb filter mlwh_json_cb];
   my $params     = function_params($positional, @named);
 
+  sub write_json {
+    my ($self) = @_;
+    my ($json_fh, $json_hash);
+    open $json_fh, '>:encoding(UTF-8)', $self->mlwh_json or
+      self->logconfess(q[could not open ml warehouse json file] .
+      qq[$self->mlwh_json]);
+    $json_hash = {
+      version  => $JSON_FILE_VERSION,
+      irods_collection => $self->dest_collection
+    };
+    print $json_fh encode_json($json_hash) or
+      self->logconfess(q[could not write to ml warehouse json file ] .
+      qq[$self->mlwh_json]);
+
+    close $json_fh or
+      self->logconfess(q[could not close ml warehouse json file] .
+      qq[$self->mlwh_json]);
+    return 1;
+  }
+
   sub publish_tree {
     my ($self, $files) = $params->parse(@_);
 
+    if (defined $self->mlwh_json && defined $params->mlwh_json_cb) {
+      $self->logconfess('The mlwh_json_cb cannot be defined with mlwh_json variable set');
+    }
     if (defined $params->filter) {
       ref $params->filter eq 'CODE' or
           $self->logconfess('The filter argument must be a CodeRef');
@@ -173,6 +207,10 @@ has 'require_checksum_cache' =>
       $num_files     += $nf;
       $num_processed += $np;
       $num_errors    += $ne;
+    }
+
+    if (defined $self->mlwh_json) {
+      $self->write_json();
     }
 
     return ($num_files, $num_processed, $num_errors);

--- a/lib/WTSI/NPG/HTS/TreePublisher.pm
+++ b/lib/WTSI/NPG/HTS/TreePublisher.pm
@@ -68,6 +68,7 @@ has 'mlwh_json' =>
   (isa           => 'Str',
   is             => 'ro',
   required       => 0,
+  predicate     => 'has_mlwh_json',
   documentation  => 'The json file to which information about the irods collection ' .
                     'folder will be added. Cannot be used with mlwh_json_cb defined.');
 
@@ -92,8 +93,8 @@ has 'mlwh_json' =>
                CodeRef. Optional.
 
                mlwh_json_cb
-               Callback writing information of a collection to JSON file.
-               CodeRef. Optional. Cannot be used with mlwh_json attribute set.
+               Callback writing information about data objects to a JSON file.
+               CodeRef. Optional. Cannot be used with the mlwh_json attribute set.
 
   Example    : my ($num_files, $num_processed, $num_errors) =
                  $pub->publish_tree($files,
@@ -141,8 +142,8 @@ has 'mlwh_json' =>
   sub publish_tree {
     my ($self, $files) = $params->parse(@_);
 
-    if (defined $self->mlwh_json && defined $params->mlwh_json_cb) {
-      $self->logconfess('The mlwh_json_cb cannot be defined with mlwh_json variable set');
+    if ($self->has_mlwh_json && defined $params->mlwh_json_cb) {
+      $self->logconfess('The mlwh_json_cb cannot be defined with the mlwh_json attribute set');
     }
     if (defined $params->filter) {
       ref $params->filter eq 'CODE' or
@@ -209,7 +210,7 @@ has 'mlwh_json' =>
       $num_errors    += $ne;
     }
 
-    if (defined $self->mlwh_json) {
+    if ($self->has_mlwh_json) {
       $self->write_json();
     }
 

--- a/lib/WTSI/NPG/HTS/TreePublisher.pm
+++ b/lib/WTSI/NPG/HTS/TreePublisher.pm
@@ -80,6 +80,10 @@ has 'require_checksum_cache' =>
                Function returning true for each file path to be published.
                CodeRef. Optional.
 
+               mlwh_json_cb
+               Callback writing metadata of all objects to a JSON file.
+               CodeRef. Optional.
+
   Example    : my ($num_files, $num_processed, $num_errors) =
                  $pub->publish_tree($files,
                                     primary_cb   => sub { ... },

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -16,14 +16,43 @@ use WTSI::NPG::iRODS;
 
 use JSON;
 use Readonly;
+use IPC::System::Simple qw(system);
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
 
 my $pid          = $PID;
 my $test_counter = 0;
 my $data_path    = 't/data';
+my $bin_path     = 'bin';
 
 my $irods_tmp_coll;
+
+sub write_json {
+  my ($json_filename, $irods_collection) = @_;
+  if (defined $json_filename && (not $json_filename =~ qr/^\s*$/sxm)
+      && defined $irods_collection && (not $irods_collection =~ qr/^\s*$/sxm)) {
+    Readonly::Scalar my $JSON_FILE_VERSION => '1.0';
+
+    my ($json_fh, $json_hash);
+    open $json_fh, '>:encoding(UTF-8)', $json_filename or
+      self->logcroak(q[could not open ml warehouse json file] .
+      qq[$json_filename]);
+    $json_hash = {
+      version  => $JSON_FILE_VERSION,
+      irods_collection => $irods_collection
+    };
+    print $json_fh encode_json($json_hash) or
+      self->logcroak(q[could not write to ml warehouse json file ] .
+      qq[$json_filename]);
+
+    close $json_fh or
+      self->logcroak(q[could not close ml warehouse json file] .
+      qq[$json_filename]);
+  } else {
+    self->logcroak(q[Wrong parameters in write_json]);
+  }
+  return 1;
+}
 
 sub setup_test : Test(setup) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
@@ -65,54 +94,14 @@ sub publish_tree : Test(59) {
     return ({attribute => 'extra', value => 'evalue'})
   };
 
-  my $mlwh_json_filename = qq[metadata.json];
-  my $mlwh_json_cb = sub {
-    # DataObject, path to file folder, collection file
-    my ($obj, $collection, $file) = @_;
-      if (defined $mlwh_json_filename) { 
-        Readonly::Scalar my $JSON_FILE_VERSION => '1.0';
-        my $mlwh_hash = {
-          irods_root_collection    => $collection,
-          irods_data_relative_path => $file
-        };
-        my ($json_fh, $json_hash);
-        if (-e $mlwh_json_filename) {
-          open $json_fh, '+<:encoding(UTF-8)', $mlwh_json_filename or
-            self->logcroak(q[could not open ml warehouse json file] .
-            qq[$mlwh_json_filename]);
-          $json_hash = decode_json <$json_fh>;
-        }
-        else {
-          open $json_fh, '>:encoding(UTF-8)', $mlwh_json_filename or
-            self->logcroak(q[could not open ml warehouse json file] .
-            qq[$mlwh_json_filename]);
-          $json_hash = {
-            version  => $JSON_FILE_VERSION,
-            irods_top_collection_folder => $irods_tmp_coll,
-            products => [],
-          };
-        }
-        push @{$json_hash->{products}}, $mlwh_hash;
-
-        seek $json_fh, 0, 0;
-
-        print $json_fh encode_json($json_hash) or
-          self->logcroak(q[could not write to ml warehouse json file ] .
-          qq[$mlwh_json_filename]);
-
-        close $json_fh or
-          self->logcroak(q[could not close ml warehouse json file] .
-          qq[$mlwh_json_filename]);
-      }
-      return 1;
-    };
-
   my ($num_files, $num_processed, $num_errors) =
       $pub->publish_tree(\@files,
                          primary_cb   => $primary_avus,
                          secondary_cb => $secondary_avus,
-                         extra_cb     => $extra_avus,
-                         mlwh_json_cb => $mlwh_json_cb);
+                         extra_cb     => $extra_avus);
+
+  my $mlwh_json_filename = qq[metadata.json];
+  write_json($mlwh_json_filename, $pub->dest_collection);
 
   my $num_expected = scalar @files;
   cmp_ok($num_errors,    '==', 0, 'No errors on publishing');
@@ -149,6 +138,25 @@ sub publish_tree : Test(59) {
   check_metadata($irods, map { catfile($irods_tmp_coll, $_) } @observed_paths);
 
   ok(-e $mlwh_json_filename, "File json in public_tree correctly created");
+  unlink $mlwh_json_filename;
+}
+
+sub npg_publish_tree_script : Test(3) {
+  my $source_path = "${data_path}/treepublisher";
+  my $mlwh_json_filename = "metadata.json";
+
+  my @script_args = (qq[--mlwh_json], ${mlwh_json_filename}, qq[--collection], ${irods_tmp_coll}, qq[--source_directory], ${source_path});
+  my $result = system($^X, "${bin_path}/npg_publish_tree.pl", @script_args);
+  ok($result == 0, 'Script npg_publish_tree.pl correctly exited');
+
+  ok(-e $mlwh_json_filename, "File json in npg_publish_tree_script correctly created");
+  my ($json_fh, $json_hash);
+  open $json_fh, '<:encoding(UTF-8)', $mlwh_json_filename or
+    self->logcroak(q[could not open ml warehouse json file] .
+    qq[$mlwh_json_filename]);
+  $json_hash = decode_json <$json_fh>;
+  ok($json_hash->{irods_collection} eq ${irods_tmp_coll}, 'Irods collection folder correct');
+  unlink $mlwh_json_filename;
 }
 
 sub publish_tree_filter : Test(4) {


### PR DESCRIPTION
This branch aims to add a method in the TreePublisher class. The function writes the irods top collection folder to json file only if the attribute mlwh_json is set. Issue #363.