### PR TITLE
Feature/read metadata from stdin issue365

### DIFF
--- a/bin/npg_publish_tree.pl
+++ b/bin/npg_publish_tree.pl
@@ -318,6 +318,8 @@ npg_publish_tree --source-directory <path> --collection <path>
    --source_directory The local path to load.
    --verbose          Print messages while processing. Optional.
 
+   -                  Specify a metadata file from standard input.
+
 =head1 DESCRIPTION
 
 Publish an arbitrary directory hierarchy to iRODS, set permissions and

--- a/bin/npg_publish_tree.pl
+++ b/bin/npg_publish_tree.pl
@@ -167,8 +167,8 @@ if (not $dest_collection) {
 }
 
 if (defined $metadata_file and $stdio) {
-  $log->logconfess('Metadata JSON file and metadata from STDIN options' .
-                    'cannot be specified together');
+  $log->logcroak('Metadata JSON file and metadata from STDIN options',
+                    ' cannot be specified together');
 }
 
 my $irods = WTSI::NPG::iRODS->new;

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -107,6 +107,27 @@ sub publish_tree : Test(58) {
   check_metadata($irods, map { catfile($irods_tmp_coll, $_) } @observed_paths);
 }
 
+sub npg_publish_tree_pl_metadata_from_stdin : Test(3) {
+  my $source_path = "${data_path}/treepublisher";
+  my @attributes;  
+  push @attributes, {attribute => 'attr1', value => 'val1', units => q[]};
+  push @attributes, {attribute => 'attr2', value => 'val2', units => q[]};
+
+  my $metadata_text = JSON->new->utf8->encode(\@attributes);
+  my $metadata_file_in = "metadata.json.in";
+  open my $md_stdio, '>', $metadata_file_in or die "Cannot open ${metadata_file_in} for test";
+  print $md_stdio "$metadata_text\n";
+
+  my $script_args = qq[--collection ${irods_tmp_coll} --source_directory ${source_path} -];
+  ok(system("cat ${metadata_file_in} | ${bin_path}/npg_publish_tree.pl ${script_args}") == 0, 'Script npg_publish_tree.pl with metadata in stdin');
+
+  my $imeta_output = `imeta ls -C ${irods_tmp_coll}`;
+  foreach my $avu (@attributes) {
+    ok($imeta_output =~ m/attribute: $avu->{attribute}\nvalue: $avu->{value}\nunits: $avu->{units}/, 'Expected attributes from stdin found by imeta');
+  }
+  unlink $metadata_file_in;
+}
+
 sub npg_publish_tree_pl_writes_json : Test(2) {
   my $source_path = "${data_path}/treepublisher";
   my $mlwh_json_filename = "metadata.json";

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -128,6 +128,23 @@ sub npg_publish_tree_pl_metadata_from_stdin : Test(3) {
   unlink $metadata_file_in;
 }
 
+sub npg_publish_tree_pl_metadata_from_stdin_plus_cmd : Test(1) {
+  my $source_path = "${data_path}/treepublisher";
+  my @attributes;  
+  push @attributes, {attribute => 'attr1', value => 'val1', units => q[]};
+  push @attributes, {attribute => 'attr2', value => 'val2', units => q[]};
+
+  my $metadata_text = JSON->new->utf8->encode(\@attributes);
+  my $metadata_file_in = "metadata.json.in";
+  open my $md_stdio, '>', $metadata_file_in or die "Cannot open ${metadata_file_in} for test";
+  print $md_stdio "${metadata_text}\n";
+
+  my $script_args = qq[--collection ${irods_tmp_coll} --source_directory ${source_path} --metadata ${metadata_file_in} -];
+  ok(system("cat ${metadata_file_in} | ${bin_path}/npg_publish_tree.pl ${script_args}") != 0, 'npg_publish_tree.pl with metadata in stdin (stdin and cmd clash)');
+
+  unlink $metadata_file_in;
+}
+
 sub npg_publish_tree_pl_writes_json : Test(2) {
   my $source_path = "${data_path}/treepublisher";
   my $mlwh_json_filename = "metadata.json";


### PR DESCRIPTION
The Pull Request aims to add a feature requested in the Issue #365. It adds the possibility to specify a json file with metadata from standard input:
- Added standard input option for metadata to npg_publish_tree.pl
- Added test for checking that the attributes are set correctly
- Added test for checking that the metadata file is specified with exactly one option (between command line and stdin)