### PR TITLE
Fix the object limit for the iRODS single replica object-finding query

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 Upcoming
+Release 2.37.1
+
+  - Bugfix: Object limit for the iRODS single replica object-finding query
 
 Release 2.37.0
 

--- a/lib/WTSI/NPG/Data/SingleReplicaMetaUpdater.pm
+++ b/lib/WTSI/NPG/Data/SingleReplicaMetaUpdater.pm
@@ -228,10 +228,10 @@ sub _find_candidate_objects {
       $self->logcroak("Failed close STDOUT of iquest '$iquest_cmd': $ERRNO");
 
   my $paths = $self->_parse_iquest_records(@records);
-  $self->debug(sprintf q[Found %d paths], scalar @{$paths});
+  my $found = scalar @{$paths};
+  $self->debug(sprintf q[Found %d paths], $found);
 
-  if ($limit > 0) {
-    my $found = scalar @{$paths};
+  if ($limit and $limit < $found) {
     $paths = [@{$paths}[0 .. $limit-1]];
     my $limited = scalar @{$paths};
 


### PR DESCRIPTION
Fixes the case where the limit was greater than the number of results
returned by the query. The bug caused the results to be padded with
empty results to the count of the supplied limit.