### PR TITLE
Demote error to warning when EBI and iRODS checksums are different

### DIFF
--- a/lib/WTSI/NPG/Data/SingleReplicaMetaUpdater.pm
+++ b/lib/WTSI/NPG/Data/SingleReplicaMetaUpdater.pm
@@ -15,6 +15,9 @@ use WTSI::DNAP::Utilities::Params qw[function_params];
 use WTSI::NPG::iRODS;
 use WTSI::NPG::iRODS::DataObject;
 
+use warnings;
+use warnings::register;
+
 with qw[
   WTSI::DNAP::Utilities::Loggable
 ];
@@ -151,10 +154,13 @@ sub _do_update_metadata {
 
       my $ebi_sub_md5 = $obj->get_avu($EBI_SUB_MD5_ATTR)->{value};
       if (not $ebi_sub_md5 eq $obj->checksum) {
-        croak sprintf q[object's ebi_sub_md5 %s is not equal to ] .
-                      q[the current checksum %s], $ebi_sub_md5, $obj->checksum;
+        if (warnings::enabled()) {
+          warnings::warn(
+            sprintf q[object's ebi_sub_md5 %s is not equal to ] .
+                    q[the current checksum %s], $ebi_sub_md5, $obj->checksum
+          );
+        }
       }
-
       if (not $obj->is_consistent_size) {
         croak sprintf q[object size %d is not consistent with its checksum %s],
           $obj->size, $obj->has_checksum ? $obj->checksum : 'undef';

--- a/lib/WTSI/NPG/Data/SingleReplicaMetaUpdater.pm
+++ b/lib/WTSI/NPG/Data/SingleReplicaMetaUpdater.pm
@@ -15,9 +15,6 @@ use WTSI::DNAP::Utilities::Params qw[function_params];
 use WTSI::NPG::iRODS;
 use WTSI::NPG::iRODS::DataObject;
 
-use warnings;
-use warnings::register;
-
 with qw[
   WTSI::DNAP::Utilities::Loggable
 ];
@@ -154,12 +151,10 @@ sub _do_update_metadata {
 
       my $ebi_sub_md5 = $obj->get_avu($EBI_SUB_MD5_ATTR)->{value};
       if (not $ebi_sub_md5 eq $obj->checksum) {
-        if (warnings::enabled()) {
-          warnings::warn(
-            sprintf q[object's ebi_sub_md5 %s is not equal to ] .
-                    q[the current checksum %s], $ebi_sub_md5, $obj->checksum
-          );
-        }
+        $self->warn(
+          sprintf q[object's ebi_sub_md5 %s is not equal to ] .
+                  q[the current checksum %s], $ebi_sub_md5, $obj->checksum
+        );
       }
       if (not $obj->is_consistent_size) {
         croak sprintf q[object size %d is not consistent with its checksum %s],

--- a/t/lib/WTSI/NPG/Data/SingleReplicaMetaUpdaterTest.pm
+++ b/t/lib/WTSI/NPG/Data/SingleReplicaMetaUpdaterTest.pm
@@ -120,8 +120,8 @@ sub avoid_inconsistent_objects : Test(4) {
   $obj1->remove_avu($ebi_md5, '68b22040025784da775f55cfcb6dee2e');
 
   # Make the second of the candidate objects inconsistent by changing its
-  # ebi_sub_md5 metadata. This means the object will be found, but will
-  # raise an error on processing.
+  # ebi_sub_md5 metadata. This means the object will be found, and will
+  # raise a warning on processing with no error.
   my $obj2 =
     WTSI::NPG::iRODS::DataObject->new($irods,
                                       "$irods_tmp_coll/single_replica/2.txt");
@@ -131,10 +131,10 @@ sub avoid_inconsistent_objects : Test(4) {
     $m->update_single_replica_metadata(end_date => $middle);
   is($num_objs, 4, 'Expected 4 objects found');
   is($num_processed, 4, 'Expected 4 objects processed');
-  is($num_errors, 1, 'Expected 1 error');
+  is($num_errors, 0, 'Expected 0 error');
 
   my $sr = $WTSI::NPG::Data::SingleReplicaMetaUpdater::SINGLE_REPLICA_ATTR;
-  my @expected = map { "$irods_tmp_coll/single_replica/$_.txt" } 3 .. 5;
+  my @expected = map { "$irods_tmp_coll/single_replica/$_.txt" } 2 .. 5;
 
   my @observed = $irods->find_objects_by_meta($irods_tmp_coll, [$sr => 1]);
   is_deeply(\@observed, \@expected, 'Single replica metadata added') or diag

--- a/t/lib/WTSI/NPG/Data/SingleReplicaMetaUpdaterTest.pm
+++ b/t/lib/WTSI/NPG/Data/SingleReplicaMetaUpdaterTest.pm
@@ -120,8 +120,8 @@ sub avoid_inconsistent_objects : Test(4) {
   $obj1->remove_avu($ebi_md5, '68b22040025784da775f55cfcb6dee2e');
 
   # Make the second of the candidate objects inconsistent by changing its
-  # ebi_sub_md5 metadata. This means the object will be found, and will
-  # raise a warning on processing with no error.
+  # ebi_sub_md5 metadata. This means the object will be found, and a warning 
+  # will be logged on processing with no error.
   my $obj2 =
     WTSI::NPG::iRODS::DataObject->new($irods,
                                       "$irods_tmp_coll/single_replica/2.txt");


### PR DESCRIPTION
The following PR will add an enhancement for the Issue #378. Previously, An error was raised when EBI and iRODS checksums were different during the submission. With the new enhancement it raises a warning. The test code available for the function is updated as well.