### PR TITLE
Update ci test workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,17 +23,12 @@ jobs:
           - perl: "5.22.4"
             irods: "4.2.7"
             server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
-            baton: "3.2.0"
+            baton: "3.3.0"
             experimental: false
-          - perl: "5.22.4"
-            irods: "4.2.10"
-            server_image: "wsinpg/ub-18.04-irods-4.2.10:latest"
-            baton: "3.2.0"
-            experimental: true
           - perl: "5.22.4"
             irods: "4.2.11"
             server_image: "wsinpg/ub-18.04-irods-4.2.11:latest"
-            baton: "3.2.0"
+            baton: "3.3.0"
             experimental: true
 
     services:

--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Upcoming
+
+  - Update baton version in github actions workflow to 3.3.0
+  - Remove iRODS 4.2.10 from github actions workflow
+  
 Release 2.37.1
 
   - Bugfix: Object limit for the iRODS single replica object-finding query


### PR DESCRIPTION
Update to baton 3.3.0 and remove iRODS 4.2.10 in github actions workflow