### PR TITLE
PacBio - extend runauditor for subdirectoies

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,8 @@ Upcoming
   - Update baton version in github actions workflow to 3.3.0
   - Remove iRODS 4.2.10 from github actions workflow
   - archive metrics files produced by SamHaplotag
+  - PacBio - extend runauditor to cope with fixing permissions on
+    runfolder subdirectories created by deplexing on board
 
 Release 2.37.1
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -16520,7 +16520,7 @@ t/lib/WTSI/NPG/HTS/LIMSFactoryTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/MetaUpdaterTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/RunPublisherTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/SeqDataObjectTest.pm
-t/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisFastaManager.pm
+t/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisFastaManagerTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisMonitorTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisPublisherTest.pm
 t/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisReportTest.pm


### PR DESCRIPTION
Run folders can now contain 1 or more tag directory within each cell directory where deplexing has been run on the instrument - therefore the runauditor has been extended to check and correct permissions on those directories too. Directories are rsync'd from the instrument as user pb with only the user write permission set. 

(+ 1 small MANIFEST file correction)