### PR TITLE
Feature: add logconf option to npg_publish_tree

### DIFF
--- a/bin/npg_publish_tree.pl
+++ b/bin/npg_publish_tree.pl
@@ -301,7 +301,10 @@ npg_publish_tree --source-directory <path> --collection <path>
                       published, all others will be ignored. If more than
                       one regex is supplied, the matches for all of them
                       are aggregated.
-
+   --logconf          A file containing log4perl configuration with log
+                      dispatchers. It may include one or more dispatchers
+                      to log messages to different resources
+                      (such as screen, files...).
    --max-errors       The maximum number of errors permitted before aborting.
                       Optional, defaults to unlimited.
    --metadata         A JSON file containing metadata to be added to the

--- a/bin/npg_publish_tree.pl
+++ b/bin/npg_publish_tree.pl
@@ -51,6 +51,7 @@ my $stdio;
 my @include;
 my @exclude;
 my @groups;
+my $log4perl_config;
 
 GetOptions('collection=s'                        => \$dest_collection,
            'debug'                               => \$debug,
@@ -61,6 +62,7 @@ GetOptions('collection=s'                        => \$dest_collection,
              pod2usage(-verbose => 2, -exitval => 0);
            },
            'include=s'                           => \@include,
+           'logconf=s'                           => \$log4perl_config,
            'max-errors|max_errors=i'             => \$max_errors,
            'metadata=s'                          => \$metadata_file,
            'mlwh-json|mlwh_json=s'               => \$mlwh_json_filename,
@@ -69,14 +71,19 @@ GetOptions('collection=s'                        => \$dest_collection,
            'verbose'                             => \$verbose,
            q[]                                   => \$stdio);
 
-if ($verbose and not $debug) {
-  Log::Log4perl::init(\$log_config);
+if ($log4perl_config) {
+  Log::Log4perl::init($log4perl_config);
 }
 else {
-  my $level = $debug ? $DEBUG : $WARN;
-  Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
-                            level  => $level,
-                            utf8   => 1});
+  if ($verbose and not $debug) {
+    Log::Log4perl::init(\$log_config);
+  }
+  else {
+    my $level = $debug ? $DEBUG : $WARN;
+    Log::Log4perl->easy_init({layout => '%d %-5p %c - %m%n',
+                              level  => $level,
+                              utf8   => 1});
+  }
 }
 
 my $log = Log::Log4perl->get_logger('main');

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -283,10 +283,10 @@ sub npg_publish_tree_pl_logconf : Test(1) {
   my $source_path = "${data_path}/treepublisher";
 
   my @script_args = (
-    q[--collection], ${irods_tmp_coll},
-    q[--source_directory], ${source_path},
+    q[--collection], $irods_tmp_coll,
+    q[--source_directory], $source_path,
     q[--logconf], q[t/log4perl_test.conf]);
-  ok(system($^X, "${bin_path}/npg_publish_tree.pl", @script_args) == 0,
+  ok(system("$bin_path/npg_publish_tree.pl", @script_args) == 0,
     'Correctly exited with logconf option');
 }
 

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -279,6 +279,17 @@ sub publish_tree_filter : Test(4) {
       diag explain \@observed_paths;
 }
 
+sub npg_publish_tree_pl_logconf : Test(1) {
+  my $source_path = "${data_path}/treepublisher";
+
+  my @script_args = (
+    q[--collection], ${irods_tmp_coll},
+    q[--source_directory], ${source_path},
+    q[--logconf], q[t/log4perl_test.conf]);
+  ok(system($^X, "${bin_path}/npg_publish_tree.pl", @script_args) == 0,
+    'Correctly exited with logconf option');
+}
+
 sub observed_data_objects {
   my ($irods, $dest_collection, $root_collection) = @_;
 

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -280,7 +280,7 @@ sub publish_tree_filter : Test(4) {
 }
 
 sub npg_publish_tree_pl_logconf : Test(1) {
-  my $source_path = "${data_path}/treepublisher";
+  my $source_path = "$data_path/treepublisher";
 
   my @script_args = (
     q[--collection], $irods_tmp_coll,

--- a/t/log4perl_test.conf
+++ b/t/log4perl_test.conf
@@ -1,0 +1,13 @@
+log4perl.logger = INFO, A1
+
+# Errors from WTSI::NPG::iRODS are propagated in the code to callers,
+# so we do not need to see them directly:
+log4perl.logger.WTSI.NPG.iRODS = OFF, A1
+
+log4perl.appender.A1 = Log::Log4perl::Appender::Screen
+log4perl.appender.A1.layout = Log::Log4perl::Layout::PatternLayout
+log4perl.appender.A1.layout.ConversionPattern = %d %-5p %c - %m%n
+log4perl.appender.A1.utf8 = 1
+
+# Prevent duplicate messages with a non-Log4j-compliant Log4perl option
+log4perl.oneMessagePerAppender = 1


### PR DESCRIPTION
This branch adds the `--logconf` option to `npg_publish_tree.pl`.

The `--logconf` option is required when iRODS messages should be logged to multiple resources (screen, files...). In particular, when `npg_publish_tree.pl` is run from the pipeline, a configuration file can be provided to it with one or more custom log dispatchers.