### PR TITLE
Unify location file writing using the LocationWriter class

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Unreleased
 
+  - Unify location file writing for Illumina and PacBio products
+  
 Release 2.43.0
 
   - Change PacBio min deplex default as all data now HiFi

--- a/MANIFEST
+++ b/MANIFEST
@@ -16761,6 +16761,7 @@ t/lib/WTSI/NPG/OM/BioNano/RunFinderTest.pm
 t/lib/WTSI/NPG/OM/BioNano/RunPublisherTest.pm
 t/lib/WTSI/NPG/OM/BioNano/Saphyr/RunPublisherTest.pm
 t/log_publisher.t
+t/location_writer.t
 t/pacbio_meta_updater.t
 t/pacbio_run_publisher.t
 t/pacbio_seq_data_object.t
@@ -16781,4 +16782,3 @@ t/saphyr_run_publisher.t
 t/seqchksum.t
 t/subtrack_client.t
 t/tree_publisher.t
-t/write_locations.t

--- a/bin/npg_publish_illumina_run.pl
+++ b/bin/npg_publish_illumina_run.pl
@@ -152,8 +152,10 @@ sub handler {
 
   $log->info('Writing restart file ', $publisher->restart_file);
   $publisher->write_restart_file;
-  $log->info('Writing locations file ', $publisher->mlwh_locations->path);
-  $publisher->write_locations;
+  if ($mlwh_json) {
+    $log->info('Writing locations file ', $publisher->mlwh_locations->path);
+    $publisher->write_locations;
+  }
   $log->error("Exiting due to $signal");
   exit 1;
 }

--- a/bin/npg_publish_illumina_run.pl
+++ b/bin/npg_publish_illumina_run.pl
@@ -14,9 +14,11 @@ use Pod::Usage;
 use WTSI::DNAP::Warehouse::Schema;
 use WTSI::NPG::HTS::Illumina::RunPublisher;
 use WTSI::NPG::HTS::LIMSFactory;
+use WTSI::NPG::HTS::LocationWriter;
 
 our $VERSION = '';
 our $DEFAULT_ZONE = 'seq';
+my $ILLUMINA = 'Illumina';
 
 my $verbose_config = << 'LOGCONF'
 log4perl.logger = ERROR, A1
@@ -133,7 +135,8 @@ if ($max_errors) {
   push @pub_init_args, max_errors => $max_errors;
 }
 if ($mlwh_json) {
-  push @pub_init_args, mlwh_json => $mlwh_json;
+  push @pub_init_args, mlwh_locations =>
+    WTSI::NPG::HTS::LocationWriter->new($mlwh_json, $ILLUMINA);
 }
 
 my $publisher = WTSI::NPG::HTS::Illumina::RunPublisher->new(@pub_init_args);
@@ -145,6 +148,8 @@ sub handler {
 
   $log->info('Writing restart file ', $publisher->restart_file);
   $publisher->write_restart_file;
+  $log->info('Writing locations file ', $publisher->mlwh_locations->path);
+  $publisher->write_locations;
   $log->error("Exiting due to $signal");
   exit 1;
 }

--- a/bin/npg_publish_illumina_run.pl
+++ b/bin/npg_publish_illumina_run.pl
@@ -18,7 +18,7 @@ use WTSI::NPG::HTS::LocationWriter;
 
 our $VERSION = '';
 our $DEFAULT_ZONE = 'seq';
-my $ILLUMINA = 'Illumina';
+my $ILLUMINA = 'illumina';
 
 my $verbose_config = << 'LOGCONF'
 log4perl.logger = ERROR, A1
@@ -135,8 +135,12 @@ if ($max_errors) {
   push @pub_init_args, max_errors => $max_errors;
 }
 if ($mlwh_json) {
+  my @writer_init_args = (path =>$mlwh_json, platform_name => $ILLUMINA);
+  if ($alt_process){
+    push @writer_init_args, alt_process => 1;
+  }
   push @pub_init_args, mlwh_locations =>
-    WTSI::NPG::HTS::LocationWriter->new($mlwh_json, $ILLUMINA);
+    WTSI::NPG::HTS::LocationWriter->new(@writer_init_args);
 }
 
 my $publisher = WTSI::NPG::HTS::Illumina::RunPublisher->new(@pub_init_args);

--- a/bin/npg_publish_tree.pl
+++ b/bin/npg_publish_tree.pl
@@ -45,7 +45,6 @@ my $metadata_file;
 my $restart_file;
 my $source_directory;
 my $verbose;
-my $mlwh_json_filename;
 my $stdio;
 
 my @include;
@@ -65,7 +64,6 @@ GetOptions('collection=s'                        => \$dest_collection,
            'logconf=s'                           => \$log4perl_config,
            'max-errors|max_errors=i'             => \$max_errors,
            'metadata=s'                          => \$metadata_file,
-           'mlwh-json|mlwh_json=s'               => \$mlwh_json_filename,
            'restart-file|restart_file=s'         => \$restart_file,
            'source-directory|source_directory=s' => \$source_directory,
            'verbose'                             => \$verbose,
@@ -186,9 +184,6 @@ my @init_args = (dest_collection        => $dest_collection,
                 source_directory       => $source_directory);
 if ($max_errors) {
   push @init_args, max_errors => $max_errors;
-}
-if (defined $mlwh_json_filename) {
-  push @init_args, mlwh_json => $mlwh_json_filename;
 }
 my $coll = WTSI::NPG::iRODS::Collection->new($irods, $dest_collection);
 my $publisher = WTSI::NPG::HTS::TreePublisher->new(@init_args);
@@ -315,9 +310,6 @@ npg_publish_tree --source-directory <path> --collection <path>
                       E.g. [{"attribute": "attr1", "value": "val1"},
                             {"attribute": "attr2", "value": "val2"}]
 
-   --mlwh-json        
-   --mlwh_json        Write information about the root collection to json file. 
-                      Optional.
    --restart-file
    --restart_file     A file path where a record of successfully published
                       files will be recorded in JSON format on exit. If the

--- a/lib/WTSI/NPG/HTS/BatchPublisher.pm
+++ b/lib/WTSI/NPG/HTS/BatchPublisher.pm
@@ -115,7 +115,7 @@ has 'require_checksum_cache' =>
 ## no critic (Subroutines::ProhibitExcessComplexity)
 {
   my $positional = 3;
-  my @named      = qw[primary_cb secondary_cb extra_cb mlwh_json_cb];
+  my @named      = qw[primary_cb secondary_cb extra_cb];
   my $params     = function_params($positional, @named);
 
   sub publish_file_batch {
@@ -147,13 +147,6 @@ has 'require_checksum_cache' =>
       ref $params->extra_cb eq 'CODE' or
           $self->logconfess('The extra_cb argument must be a CodeRef');
       $extra_cb = $params->extra_cb;
-    }
-
-    my $mlwh_json_cb = sub {return 1};
-    if (defined $params->mlwh_json_cb) {
-      ref $params->mlwh_json_cb eq 'CODE' or
-          $self->logconfess('The mlwh_json_cb argument must be a CodeRef');
-      $mlwh_json_cb = $params->mlwh_json_cb;
     }
 
     my $publisher =
@@ -228,11 +221,6 @@ has 'require_checksum_cache' =>
         $self->publish_state->set_published($file);
         $self->info("Published '$dest' [$num_processed / $num_files]");
 
-        # The mlwh_json_callback is deprecated, and will be removed once the
-        # illumina code is refactored to use the LocationWriter
-        if (!$mlwh_json_cb->($obj, $dest_coll, $filename)){
-          $self->logcroak("Failed to add '$file' to ml warehouse json file");
-        }
         if ($self->mlwh_locations){
           my $target;
           my $pid;

--- a/lib/WTSI/NPG/HTS/BatchPublisher.pm
+++ b/lib/WTSI/NPG/HTS/BatchPublisher.pm
@@ -237,8 +237,8 @@ has 'require_checksum_cache' =>
               last;
             }
           }
-          my ($suffix) = $filename =~ m{[.]([^.]+)$}msx;
-          if ($target && any { $suffix eq $_ } qw/bam cram/) {
+          my ($ext) = $filename =~ m/[.]([^.]+)$/msx;
+          if ($target && any { $ext eq $_ } qw/bam cram/) {
             $self->mlwh_locations->add_location(
               pid  => $pid,
               coll => $dest_coll,

--- a/lib/WTSI/NPG/HTS/BatchPublisher.pm
+++ b/lib/WTSI/NPG/HTS/BatchPublisher.pm
@@ -228,8 +228,11 @@ has 'require_checksum_cache' =>
           # The simplest way to obtain product ids and to discover whether an
           # object is the target of a run/analysis is to search its metadata.
           for my $avu (@primary_avus){
-            if ($avu->{attribute} eq 'target'){
-              $target = $avu->{value};
+            if (
+                (any { $avu->{attribute} eq $_ } qw/target alt_target/) &&
+                ($avu->{value} == 1)
+            ){
+                $target = 1;
             }elsif ($avu->{attribute} eq 'id_product') {
               $pid = $avu->{value};
             }

--- a/lib/WTSI/NPG/HTS/BatchPublisher.pm
+++ b/lib/WTSI/NPG/HTS/BatchPublisher.pm
@@ -5,6 +5,7 @@ use namespace::autoclean;
 use Data::Dump qw[pp];
 use File::Basename;
 use File::Spec::Functions qw[catfile];
+use List::MoreUtils qw[any];
 use Moose;
 use MooseX::StrictConstructor;
 use Try::Tiny;
@@ -236,7 +237,8 @@ has 'require_checksum_cache' =>
               last;
             }
           }
-          if ($target) {
+          my ($suffix) = $filename =~ m{[.]([^.]+)$}msx;
+          if ($target && any { $suffix eq $_ } qw/bam cram/) {
             $self->mlwh_locations->add_location(
               pid  => $pid,
               coll => $dest_coll,

--- a/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
@@ -243,7 +243,9 @@ sub publish_collection {
     }
 
     $self->write_restart_file;
-    $self->write_locations;
+    if ($self->mlwh_locations) {
+      $self->write_locations;
+    }
 
     return ($num_files, $num_processed, $num_errors);
   }
@@ -637,10 +639,12 @@ sub _make_tree_publisher {
   my @init_args = (dest_collection  => $self->publish_collection,
                    force            => $self->force,
                    irods            => $self->irods,
-                   mlwh_locations   => $self->mlwh_locations,
                    obj_factory      => $obj_factory,
                    publish_state    => $self->publish_state,
                    source_directory => $self->source_directory);
+  if ($self->mlwh_locations){
+    push @init_args, mlwh_locations   => $self->mlwh_locations;
+  }
   if ($self->has_max_errors) {
     if ($self->num_errors >= $self->max_errors) {
       $self->logconfess(sprintf q[Internal error: the number of publish ].

--- a/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/RunPublisher.pm
@@ -37,11 +37,6 @@ our $VERSION = '';
 our $DEFAULT_ROOT_COLL       = '/seq';
 our $NUM_READS_JSON_PROPERTY = 'num_total_reads';
 
-Readonly::Scalar my $JSON_FILE_VERSION => '1.0';
-Readonly::Scalar my $ILLUMINA => 'illumina';
-Readonly::Scalar my $ALT_PROCESS => 'npg-prod-alt-process';
-Readonly::Scalar my $NPG_PROD => 'npg-prod';
-
 has 'id_run' =>
   (isa           => 'NpgTrackingRunId',
    is            => 'ro',

--- a/lib/WTSI/NPG/HTS/LocationWriter.pm
+++ b/lib/WTSI/NPG/HTS/LocationWriter.pm
@@ -38,7 +38,7 @@ has 'locations' => (
                     'and lists of locations as values');
 
 has 'alt_process' => (
-  isa           => 'bool',
+  isa           => 'Bool',
   is            => 'ro',
   required      => 0,
   documentation => 'Non-standard process used');
@@ -47,6 +47,7 @@ has 'pipeline_name' =>(
   isa           => 'Str',
   is            => 'ro',
   required      => 1,
+  lazy          => 1,
   builder       => '_build_pipeline_name',
   documentation => 'The name of the pipeline used to produce the data');
 
@@ -187,8 +188,8 @@ sub write_locations{
       irods_root_collection    => $coll,
       id_product               => $pid,
       irods_data_relative_path => $path,
-      seq_platform_name        => $self->{platform_name},
-      pipeline_name            => $self->{pipeline_name}
+      seq_platform_name        => $self->platform_name,
+      pipeline_name            => $self->pipeline_name
     };
     if ($secondary_path){
       $location->{irods_secondary_data_relative_path} = $secondary_path;

--- a/lib/WTSI/NPG/HTS/LocationWriter.pm
+++ b/lib/WTSI/NPG/HTS/LocationWriter.pm
@@ -20,6 +20,7 @@ our $VERSION = '';
 Readonly::Scalar my $DELIMITER => qq[\0];
 Readonly::Scalar my $JSON_FILE_VERSION => '1.0';
 Readonly::Scalar my $NPG_PROD => 'npg-prod';
+Readonly::Scalar my $ALT_PROCESS => 'npg-prod-alt-process';
 
 has 'path' => (
   isa           => 'Str',
@@ -36,11 +37,17 @@ has 'locations' => (
   documentation => 'A hash with keys built from collection and id_product, ' .
                     'and lists of locations as values');
 
+has 'alt_process' => (
+  isa           => 'bool',
+  is            => 'ro',
+  required      => 0,
+  documentation => 'Non-standard process used');
+
 has 'pipeline_name' =>(
   isa           => 'Str',
   is            => 'ro',
   required      => 1,
-  default       => $NPG_PROD,
+  builder       => '_build_pipeline_name',
   documentation => 'The name of the pipeline used to produce the data');
 
 has 'platform_name' => (
@@ -83,6 +90,16 @@ sub _build_locations {
   }
   return $locations;
 
+}
+
+sub _build_pipeline_name{
+  my ($self) = @_;
+
+  if ($self->alt_process){
+    return $ALT_PROCESS;
+  } else {
+    return $NPG_PROD;
+  }
 }
 
 =head2 add_location

--- a/lib/WTSI/NPG/HTS/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/RunPublisher.pm
@@ -30,6 +30,13 @@ has 'source_directory' =>
    required      => 1,
    documentation => 'The directory in which to find data to publish');
 
+has 'mlwh_locations' =>
+  (isa           => 'WTSI::NPG::HTS::LocationWriter',
+   is            => 'ro',
+   required      => 0,
+   documentation => 'An object used to build and write information to be ' .
+                    'loaded into the seq_product_irods_locations table.');
+
 sub _build_dest_collection  {
   my ($self) = @_;
 
@@ -58,7 +65,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2018 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2018, 2023 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/HTS/TreePublisher.pm
+++ b/lib/WTSI/NPG/HTS/TreePublisher.pm
@@ -64,14 +64,6 @@ has 'require_checksum_cache' =>
      documentation => 'A list of file suffixes for which MD5 cache files ' .
                       'must be provided and will not be created on the fly');
 
-has 'mlwh_json' =>
-  (isa           => 'Str',
-  is             => 'ro',
-  required       => 0,
-  predicate     => 'has_mlwh_json',
-  documentation  => 'The json file to which information about the irods collection ' .
-                    'folder will be added. Cannot be used with mlwh_json_cb defined.');
-
 =head2 publish_tree
 
   Arg [1]    : File batch, ArrayRef[Str].
@@ -91,12 +83,6 @@ has 'mlwh_json' =>
                filter
                Function returning true for each file path to be published.
                CodeRef. Optional.
-
-               mlwh_json_cb
-               Callback writing information about data objects to a JSON file.
-               CodeRef. Optional. Cannot be used with the mlwh_json attribute set.
-               The mlwh_json_cb is deprecated and will be removed once the
-               illumina code is refactored to use the LocationWriter.
 
   Example    : my ($num_files, $num_processed, $num_errors) =
                  $pub->publish_tree($files,
@@ -118,35 +104,12 @@ has 'mlwh_json' =>
 
 {
   my $positional = 2;
-  my @named      = qw[primary_cb secondary_cb extra_cb filter mlwh_json_cb];
+  my @named      = qw[primary_cb secondary_cb extra_cb filter];
   my $params     = function_params($positional, @named);
-
-  sub write_json {
-    my ($self) = @_;
-    my ($json_fh, $json_hash);
-    open $json_fh, '>:encoding(UTF-8)', $self->mlwh_json or
-      self->logconfess(q[could not open ml warehouse json file] .
-      qq[$self->mlwh_json]);
-    $json_hash = {
-      version  => $JSON_FILE_VERSION,
-      irods_collection => $self->dest_collection
-    };
-    print $json_fh encode_json($json_hash) or
-      self->logconfess(q[could not write to ml warehouse json file ] .
-      qq[$self->mlwh_json]);
-
-    close $json_fh or
-      self->logconfess(q[could not close ml warehouse json file] .
-      qq[$self->mlwh_json]);
-    return 1;
-  }
 
   sub publish_tree {
     my ($self, $files) = $params->parse(@_);
 
-    if ($self->has_mlwh_json && defined $params->mlwh_json_cb) {
-      $self->logconfess('The mlwh_json_cb cannot be defined with the mlwh_json attribute set');
-    }
     if (defined $params->filter) {
       ref $params->filter eq 'CODE' or
           $self->logconfess('The filter argument must be a CodeRef');
@@ -183,6 +146,7 @@ has 'mlwh_json' =>
       my @init_args =
           (force                  => $self->force,
            irods                  => $self->irods,
+           mlwh_locations         => $self->mlwh_locations,
            obj_factory            => $self->obj_factory,
            publish_state          => $self->publish_state,
            require_checksum_cache => $self->require_checksum_cache);
@@ -205,15 +169,10 @@ has 'mlwh_json' =>
               ($subset, $dest_coll,
                primary_cb   => $params->primary_cb,
                secondary_cb => $params->secondary_cb,
-               extra_cb     => $params->extra_cb,
-               mlwh_json_cb => $params->mlwh_json_cb);
+               extra_cb     => $params->extra_cb);
       $num_files     += $nf;
       $num_processed += $np;
       $num_errors    += $ne;
-    }
-
-    if ($self->has_mlwh_json) {
-      $self->write_json();
     }
 
     return ($num_files, $num_processed, $num_errors);

--- a/lib/WTSI/NPG/HTS/TreePublisher.pm
+++ b/lib/WTSI/NPG/HTS/TreePublisher.pm
@@ -146,11 +146,14 @@ has 'require_checksum_cache' =>
       my @init_args =
           (force                  => $self->force,
            irods                  => $self->irods,
-           mlwh_locations         => $self->mlwh_locations,
            obj_factory            => $self->obj_factory,
            publish_state          => $self->publish_state,
            require_checksum_cache => $self->require_checksum_cache);
 
+      if ($self->mlwh_locations){
+
+           push @init_args, mlwh_locations => $self->mlwh_locations;
+      }
       if ($self->has_max_errors) {
         if ($num_errors >= $self->max_errors) {
           $self->error("The number of errors $num_errors reached the maximum ",

--- a/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
@@ -1048,18 +1048,18 @@ sub publish_archive_path_existing_mlwh_json : Test(2) {
     "version" => "1.0",
     "products"=>
       [
-        { # replaced during publish
-          "irods_data_relative_path" => "18448_1.cram",
-          "id_product"               => "98441df9e535436533620dcba86eef653d5749c546eb218dc9e2f7c587cec272",
-          "irods_root_collection"    => "$irods_tmp_coll/publish_entire_mlwh/Data/Intensities/BAM_basecalls_20151214-085833/no_cal/archive/",
-          "pipeline_name"            => "npg-prod-alt-process",
-          "seq_platform_name"        => "illumina"
-        },
         { # unaffected by publish
           "irods_data_relative_path" => "test.cram",
           "id_product"               => "7382ff198a7321eadcea98bb39ade23749b3bace2874bbaced29789dbcd987659",
           "irods_root_collection"    => "$irods_tmp_coll/publish_entire_mlwh/Data/Intensities/BAM_basecalls_20151214-085833/no_cal/archive/",
           "pipeline_name"            => "npg-prod",
+          "seq_platform_name"        => "illumina"
+        },
+        { # replaced during publish
+          "irods_data_relative_path" => "18448_1.cram",
+          "id_product"               => "98441df9e535436533620dcba86eef653d5749c546eb218dc9e2f7c587cec272",
+          "irods_root_collection"    => "$irods_tmp_coll/publish_entire_mlwh/Data/Intensities/BAM_basecalls_20151214-085833/no_cal/archive/",
+          "pipeline_name"            => "npg-prod-alt-process",
           "seq_platform_name"        => "illumina"
         }]};
   my $expected_json  = "t/data/mlwh_json/illumina_existing.json";

--- a/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
@@ -822,7 +822,7 @@ sub publish_merged_sec_data_samplesheet : Test(89) {
   check_common_metadata($irods, $pkg, @absolute_paths);
 }
 
-sub publish_plex_pri_data_alt_process : Test(17) {
+sub publish_plex_pri_data_alt_process : Test(16) {
   note '=== Tests in publish_plex_pri_data_alt_process';
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);
@@ -1223,18 +1223,22 @@ sub check_publish_pri_data {
 
   my $locations_file = $pub->mlwh_locations->path;
   $pub->write_locations;
-  ok(-e $locations_file, "Locations file $locations_file exists");
+  if ($composition_file =~ m/.*_phix.*/xms){
+    ok (! -e $locations_file, "Locations file not written for phix files");
+  }else {
+    ok(-e $locations_file, "Locations file $locations_file exists");
 
-  my $locations = read_json_content($locations_file);
-  my $pipeline_name = $locations->{products}[0]->{pipeline_name};
-  if ($alt_process) {
-    is($pipeline_name, 'npg-prod-alt-process',
-      'Alt process is correctly recorded in mlwh json file');
-  }else{
-    is ($pipeline_name, 'npg-prod',
-      'Normal process is correctly recorded in mlwh json file');
+    my $locations = read_json_content($locations_file);
+    my $pipeline_name = $locations->{products}[0]->{pipeline_name};
+    if ($alt_process) {
+      is($pipeline_name, 'npg-prod-alt-process',
+        'Alt process is correctly recorded in mlwh json file');
+    }
+    else {
+      is($pipeline_name, 'npg-prod',
+        'Normal process is correctly recorded in mlwh json file');
+    }
   }
-
   return $publish_coll;
 }
 

--- a/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
@@ -999,7 +999,7 @@ sub publish_archive_path_mlwh : Test(8) {
      lims_factory     => $lims_factory,
      restart_file     => catfile($tmpdir->dirname, 'published.json'),
      source_directory => $runfolder_path,
-     mlwh_json        => catfile($tmpdir->dirname, 'mlwh_irods.json'));
+     mlwh_locations   => WTSI::NPG::HTS::LocationWriter->new(catfile($tmpdir->dirname, 'mlwh_irods.json'), $ILLUMINA));
 
   my ($num_files, $num_processed, $num_errors) = $pub->publish_files;
 
@@ -1007,7 +1007,7 @@ sub publish_archive_path_mlwh : Test(8) {
   cmp_ok($num_errors,    '==', 0, 'No errors on publishing');
   cmp_ok($num_processed, '==', $num_expected, "Published $num_expected files");
 
-  my $mlwh_json = $pub->mlwh_json;
+  my $mlwh_json = $pub->mlwh_locations->path;
   ok(-e $mlwh_json, "mlwh loader json file $mlwh_json was written by publisher");
   is_deeply(read_json_content($mlwh_json),
     set_destination(read_json_content($expected_json), $irods_tmp_coll),
@@ -1084,7 +1084,7 @@ sub publish_archive_path_existing_mlwh_json : Test(2) {
      lims_factory     => $lims_factory,
      restart_file     => catfile($tmpdir->dirname, 'published.json'),
      source_directory => $runfolder_path,
-     mlwh_json        => $mlwh_json);
+     mlwh_locations   => WTSI::NPG::HTS::LocationWriter->new($mlwh_json, $ILLUMINA));
 
   $pub->publish_files;
 

--- a/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Carp;
+use Data::Dumper;
 use English qw[-no_match_vars];
 use File::Basename;
 use File::Spec::Functions qw[abs2rel catfile catdir splitdir];
@@ -306,7 +307,7 @@ sub publish_qc_files : Test(116) {
 }
 
 # Lane-level, primary and secondary data, from ML warehouse
-sub publish_lane_pri_data_mlwh : Test(21) {
+sub publish_lane_pri_data_mlwh : Test(23) {
   note '=== Tests in publish_lane_pri_data_mlwh';
   my $runfolder_path = "$data_path/sequence/151211_HX3_18448_B_HHH55CCXX";
   my $archive_path   = "$runfolder_path/Data/Intensities/" .
@@ -373,7 +374,7 @@ sub publish_lane_sec_data_mlwh : Test(79) {
 }
 
 # Lane-level, primary and secondary data, from samplesheet
-sub publish_lane_pri_data_samplesheet : Test(21) {
+sub publish_lane_pri_data_samplesheet : Test(23) {
   note '=== Tests in publish_lane_pri_data_samplesheet';
   my $runfolder_path = "$data_path/sequence/151211_HX3_18448_B_HHH55CCXX";
   my $archive_path   = "$runfolder_path/Data/Intensities/" .
@@ -450,7 +451,7 @@ sub publish_lane_sec_data_samplesheet : Test(79) {
 }
 
 # Plex-level, primary and secondary data, from ML warehouse
-sub publish_plex_pri_data_mlwh : Test(21) {
+sub publish_plex_pri_data_mlwh : Test(23) {
   note '=== Tests in publish_plex_pri_data_mlwh';
   my $runfolder_path = "$data_path/sequence/150910_HS40_17550_A_C75BCANXX";
   my $archive_path   = "$runfolder_path/Data/Intensities/" .
@@ -519,7 +520,7 @@ sub publish_plex_sec_data_mlwh : Test(59) {
 }
 
 # Plex-level, primary and secondary data, from samplesheet
-sub publish_plex_pri_data_samplesheet : Test(21) {
+sub publish_plex_pri_data_samplesheet : Test(23) {
   note '=== Tests in publish_plex_pri_data_samplesheet';
   my $runfolder_path = "$data_path/sequence/150910_HS40_17550_A_C75BCANXX";
   my $archive_path   = "$runfolder_path/Data/Intensities/" .
@@ -652,7 +653,7 @@ sub publish_plex_geno_sec_data_samplesheet : Test(73) {
 }
 
 # Merged NovaSeq data, from ML warehouse
-sub publish_merged_pri_data_mlwh : Test(19) {
+sub publish_merged_pri_data_mlwh : Test(21) {
   note '=== Tests in publish_merged_pri_data_mlwh';
   my $runfolder_path = "$data_path/sequence/180709_A00538_0010_BH3FCMDRXX";
   my $archive_path   = "$runfolder_path/Data/Intensities/" .
@@ -686,7 +687,7 @@ sub publish_merged_pri_data_mlwh : Test(19) {
 }
 
 # Merged NovaSeq data, from samplesheet
-sub publish_merged_pri_data_samplesheet : Test(19) {
+sub publish_merged_pri_data_samplesheet : Test(21) {
   note '=== Tests in publish_merged_pri_data_samplesheet';
   my $runfolder_path = "$data_path/sequence/180709_A00538_0010_BH3FCMDRXX";
   my $archive_path   = "$runfolder_path/Data/Intensities/" .
@@ -821,7 +822,7 @@ sub publish_merged_sec_data_samplesheet : Test(89) {
   check_common_metadata($irods, $pkg, @absolute_paths);
 }
 
-sub publish_plex_pri_data_alt_process : Test(13) {
+sub publish_plex_pri_data_alt_process : Test(17) {
   note '=== Tests in publish_plex_pri_data_alt_process';
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);
@@ -1459,6 +1460,10 @@ sub read_json_content {
 
   my $json = decode_json <$mlwh_json_fh>;
   close $mlwh_json_fh;
+
+  @{$json->{products}} = sort             # sort so that files with the same
+  {$a->{id_product} cmp $b->{id_product}} # contents are always equal
+    @{$json->{products}};
   return $json
 }
 

--- a/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
@@ -1040,7 +1040,7 @@ sub publish_archive_path_mlwh : Test(8) {
 }
 
 sub publish_archive_path_existing_mlwh_json : Test(2) {
-  note '=== Tests in publish_existing_mlwh_json';
+  note '=== Tests in publish_archive_path_existing_mlwh_json';
   my $runfolder_path = "$data_path/sequence/151211_HX3_18448_B_HHH55CCXX";
   my $id_run         = 18448;
   my $initial_json = {
@@ -1202,7 +1202,7 @@ sub check_publish_pri_data {
     push @writer_init_args, alt_process => 1;
   }
 
-  push @init_args, WTSI::NPG::HTS::LocationWriter->new(@writer_init_args);
+  push @init_args, mlwh_locations => WTSI::NPG::HTS::LocationWriter->new(@writer_init_args);
 
   my $pub = WTSI::NPG::HTS::Illumina::RunPublisher->new(@init_args);
 
@@ -1252,7 +1252,8 @@ sub check_publish_sec_data {
      irods            => $irods,
      lims_factory     => $lims_factory,
      restart_file     => catfile($tmpdir->dirname, 'published.json'),
-     source_directory => $archive_path);
+     source_directory => $archive_path
+    );
 
   my ($num_files, $num_processed, $num_errors) = (0, 0, 0);
   my ($nf0, $np0, $ne0) = $pub->publish_ancillary_files($composition_file);

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -15,6 +15,7 @@ use base qw[WTSI::NPG::HTS::Test];
 
 use WTSI::NPG::HTS::TreePublisher;
 use WTSI::NPG::iRODS;
+use WTSI::NPG::HTS::LocationWriter;
 
 use JSON;
 
@@ -24,6 +25,7 @@ my $pid          = $PID;
 my $test_counter = 0;
 my $data_path    = 't/data';
 my $bin_path     = 'bin';
+my $ILLUMINA     = 'illumina';
 
 my $irods_tmp_coll;
 

--- a/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/TreePublisherTest.pm
@@ -177,7 +177,7 @@ sub write_json_correct_keyvalue : Test(2) {
     (irods            => $irods,
      source_directory => $source_path,
      dest_collection  => $irods_tmp_coll,
-     mlwh_json        => $mlwh_json_filename);
+     mlwh_locations   => WTSI::NPG::HTS::LocationWriter->new($mlwh_json_filename, $ILLUMINA));
   my @files = grep { -f } $pub->list_directory($source_path, recurse => 1);
   
   $pub->publish_tree(\@files);
@@ -201,34 +201,12 @@ sub publish_tree_mlwh_json : Test(1) {
     (irods            => $irods,
      source_directory => $source_path,
      dest_collection  => $irods_tmp_coll,
-     mlwh_json        => $mlwh_json_filename);
+     mlwh_locations   => WTSI::NPG::HTS::LocationWriter->new($mlwh_json_filename, $ILLUMINA));
   my @files = grep { -f } $pub->list_directory($source_path, recurse => 1);
   
   $pub->publish_tree(\@files);
   ok(-e $mlwh_json_filename, 'File json correctly created with no callback');
   unlink $mlwh_json_filename;
-}
-
-sub publish_tree_mlwh_json_plus_cb : Test(2) {
-  my $source_path = "${data_path}/treepublisher";
-  my $mlwh_json_filename = "metadata.json";
-
-  my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
-                                    strict_baton_version => 0);
-  my $pub = WTSI::NPG::HTS::TreePublisher->new
-    (irods            => $irods,
-     source_directory => $source_path,
-     dest_collection  => $irods_tmp_coll,
-     mlwh_json        => $mlwh_json_filename);
-  my @files = grep { -f } $pub->list_directory($source_path, recurse => 1);
-  
-  dies_ok{
-    $pub->publish_tree(\@files,
-                        mlwh_json_cb => sub {
-                          return 1;
-                        });
-  }, 'publish_tree correctly exited with error (json callback clash)'; 
-  ok(! -e $mlwh_json_filename, 'No json file as expected (json callback clash)');
 }
 
 sub publish_tree_filter : Test(4) {


### PR DESCRIPTION
Also remove tree publisher writing as it does not provide enough information to load the table (no product id, platform, pipeline name, etc.).