### PR TITLE
Changes to PacBio iRODS loading to support multi plate runs.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Unreleased
 
+  - Changes to PacBio iRODS loading to support multi plate runs.
+
 Release 2.43.0
 
   - Change PacBio min deplex default as all data now HiFi

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Unreleased
 
-  - Changes to PacBio iRODS loading to support multi plate runs.
+  - Changes to PacBio iRODS loading to support multi plate runs
+    (requires npg_id_generation v4.0.0)
   - Unify location file writing for Illumina and PacBio products
   
 Release 2.43.0

--- a/lib/WTSI/NPG/HTS/PacBio/Annotator.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Annotator.pm
@@ -53,9 +53,15 @@ with qw[
         push @avus, $self->make_avu($PACBIO_WELL,              $metadata->well_name);
         push @avus, $self->make_avu($PACBIO_SAMPLE_LOAD_NAME,  $metadata->sample_load_name);
 
+
         if ($params->data_level) {
             push @avus, $self->make_avu($PACBIO_DATA_LEVEL, $params->data_level);
         }
+
+        if ($metadata->plate_number) {
+            push @avus, $self->make_avu($PACBIO_PLATE_NUMBER, $metadata->plate_number);
+        }
+
 
         # Deprecated field, used in early version of RS
         if ($metadata->has_set_number){

--- a/lib/WTSI/NPG/HTS/PacBio/MetaQuery.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/MetaQuery.pm
@@ -22,7 +22,8 @@ has 'mlwh_schema' =>
 
   Arg [1]    : PacBio run ID, Str.
   Arg [2]    : PacBio plate well, zero-padded form, Str. E.g. 'A01'.
-  Arg [3]    : Tag identifier, Optional.
+  Arg [3]    : Tag identifier, Str. Optional.
+  Arg [4]    : Plate number - only relevant for Revio runs, Int. Optional.
 
   Example    : @run_records - $obj->find_runs($id, 'A01');
   Description: Returns run records for a PabcBio run. Pre-fetches related
@@ -32,7 +33,7 @@ has 'mlwh_schema' =>
 =cut
 
 sub find_pacbio_runs {
-  my ($self, $run_id, $well, $tag_id) = @_;
+  my ($self, $run_id, $well, $tag_id, $plate_number) = @_;
 
   defined $run_id or
     $self->logconfess('A defined run_id argument is required');
@@ -44,12 +45,16 @@ sub find_pacbio_runs {
   my $query      = {pac_bio_run_name => $run_id,
                     well_label       => $well_label};
 
-  if (defined $tag_id){
+  if (defined $tag_id) {
       $query->{tag_identifier} = $tag_id;
   }
+  if (defined $plate_number) {
+      $query->{plate_number}   = $plate_number;
+  }
+
   my @unique_records = $self->mlwh_schema->resultset('PacBioRun')->search
     ($query,  {prefetch => ['sample', 'study'],
-     group_by => [qw/pac_bio_run_name well_label tag_identifier/]});
+     group_by => [qw/pac_bio_run_name plate_number well_label tag_identifier/]});
 
   my $num_records = scalar @unique_records;
   $self->debug("Found $num_records records for PacBio ",

--- a/lib/WTSI/NPG/HTS/PacBio/Metadata.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Metadata.pm
@@ -116,6 +116,14 @@ has 'version_info'  =>
    predicate     => 'has_version_info',
    documentation => 'The PacBio version info');
 
+has 'plate_number'  =>
+  (isa           => 'Int',
+   is            => 'ro',
+   required      => 0,
+   predicate     => 'has_plate_number',
+   documentation => 'The plate number - only relevant for Revio runs');
+
+
 
 around BUILDARGS => sub {
   my $orig   = shift;

--- a/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisPublisher.pm
@@ -175,12 +175,14 @@ sub publish_sequence_files {
 
     if ($tag_id) {
         my @tag_id_records = $self->find_pacbio_runs
-            ($self->_metadata->run_name, $self->_metadata->well_name, $tag_id);
+            ($self->_metadata->run_name, $self->_metadata->well_name,
+             $tag_id, $self->_metadata->plate_number);
 
         @tag_records = (@tag_id_records == 1) ? @tag_id_records :
             $self->find_pacbio_runs($self->_metadata->run_name,
                                     $self->_metadata->well_name,
-                                    $self->_get_tag_name_from_fname($filename));
+                                    $self->_get_tag_name_from_fname($filename),
+                                    $self->_metadata->plate_number);
 
         if (@tag_records != 1) {
           $self->logcroak("Unexpected barcode from $file for SMRT cell ",
@@ -192,7 +194,7 @@ sub publish_sequence_files {
     }
 
     my @all_records = $self->find_pacbio_runs($self->_metadata->run_name,
-                                              $self->_metadata->well_name);
+      $self->_metadata->well_name, undef, $self->_metadata->plate_number);
 
     my @records = (@tag_records == 1) ? @tag_records : @all_records;
 
@@ -218,11 +220,11 @@ sub publish_sequence_files {
       my $id_product;
 
       if ($tags) {
-          $id_product = $product->generate_product_id(
-            $self->_metadata->run_name, $well_label, $tags);
+        $id_product = $product->generate_product_id($self->_metadata->run_name,
+          $well_label, $tags, $self->_metadata->plate_number);
       } else {
-        $id_product = $product->generate_product_id(
-          $self->_metadata->run_name, $well_label);
+        $id_product = $product->generate_product_id($self->_metadata->run_name,
+          $well_label, undef, $self->_metadata->plate_number);
       }
 
       my @primary_avus   = $self->make_primary_metadata

--- a/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Sequel/AnalysisPublisher.pm
@@ -220,11 +220,16 @@ sub publish_sequence_files {
       my $id_product;
 
       if ($tags) {
-        $id_product = $product->generate_product_id($self->_metadata->run_name,
-          $well_label, $tags, $self->_metadata->plate_number);
+        $id_product = $product->generate_product_id(
+          $self->_metadata->run_name,
+          $well_label,
+          tags => $tags,
+          plate_number => $self->_metadata->plate_number);
       } else {
-        $id_product = $product->generate_product_id($self->_metadata->run_name,
-          $well_label, undef, $self->_metadata->plate_number);
+        $id_product = $product->generate_product_id(
+          $self->_metadata->run_name,
+          $well_label,
+          plate_number => $self->_metadata->plate_number);
       }
 
       my @primary_avus   = $self->make_primary_metadata

--- a/lib/WTSI/NPG/HTS/PacBio/Sequel/MetaXMLParser.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Sequel/MetaXMLParser.pm
@@ -41,6 +41,9 @@ our $UNIQUE_ID_TAG         = 'UniqueId';
 
 our $CCSREADSET_TAG        = 'ConsensusReadSetRef';
 
+our $SEQKITPLATE           = 'SequencingKitPlate';
+our $PLATE_NUMBER          = 'PlateNumber';
+
 =head2 parse_file
 
   Arg [1]    : Path to metadata xml file. Required.
@@ -100,6 +103,10 @@ sub parse_file {
     $dom->getElementsByTagName($prefix . $CCSREADSET_TAG)->[0]->getAttribute($UNIQUE_ID_TAG)
     : undef;
 
+  my $plate_number = $dom->getElementsByTagName($prefix . $SEQKITPLATE) ?
+    $dom->getElementsByTagName($prefix . $SEQKITPLATE)->[0]->getAttribute($PLATE_NUMBER)
+    : undef;
+
   my %versions;
   my @version_info = $dom->getElementsByTagName($prefix . $COMP_VERSION);
   foreach my $v (@version_info){
@@ -107,6 +114,7 @@ sub parse_file {
       my $vers = $v->getAttribute($CVERSION);
       $versions{$name} = $vers;
   }
+
 
   return WTSI::NPG::HTS::PacBio::Metadata->new
     (file_path          => $file_path,
@@ -122,6 +130,7 @@ sub parse_file {
      movie_name         => $movie_name,
      results_folder     => $results_folder,
      execution_mode     => $exec_mode,
+     plate_number       => $plate_number,
      version_info       => \%versions,
      );
 }

--- a/lib/WTSI/NPG/HTS/PacBio/Sequel/Product.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Sequel/Product.pm
@@ -15,6 +15,7 @@ my $ID_LENGTH = 64;
   Arg [1]    : Run name, String. Required.
   Arg [2]    : Well label, String. Required.
   Arg [3]    : Comma separated list of tag sequences, String. Optional.
+  Arg [4]    : Plate number (only relevant for Revio runs), Int. Optional.
   Example    : $id = $self->generate_product_id($run, $well, $tags);
   Description: Runs a python script which generates a product id from run,
                well and tag data.
@@ -22,14 +23,16 @@ my $ID_LENGTH = 64;
 =cut
 
 sub generate_product_id {
-  my ($self, $run_name, $well_label, $tags) = @_;
+  my ($self, $run_name, $well_label, $tags, $plate_number) = @_;
 
   my $command = join q[ ],
     $ID_SCRIPT, '--run_name', $run_name, '--well_label', $well_label;
   foreach my $tag (@{$tags}){
     $command .= join q[ ], ' --tag', $tag;
   }
+  if (defined $plate_number) { $command .= ' --plate_number '. $plate_number; }
   $self->info("Generating product id: $command");
+
   open my $id_product_script, q[-|], $command
     or $self->logconfess('Cannot generate id_product ' . $CHILD_ERROR);
   my $id_product = <$id_product_script>;

--- a/lib/WTSI/NPG/HTS/PacBio/Sequel/Product.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Sequel/Product.pm
@@ -2,6 +2,7 @@ package WTSI::NPG::HTS::PacBio::Sequel::Product;
 
 use Moose;
 use English qw[-no_match_vars];
+use WTSI::DNAP::Utilities::Params qw[function_params];
 
 with qw/WTSI::DNAP::Utilities::Loggable/;
 
@@ -14,35 +15,55 @@ my $ID_LENGTH = 64;
 
   Arg [1]    : Run name, String. Required.
   Arg [2]    : Well label, String. Required.
-  Arg [3]    : Comma separated list of tag sequences, String. Optional.
-  Arg [4]    : Plate number (only relevant for Revio runs), Int. Optional.
-  Example    : $id = $self->generate_product_id($run, $well, $tags);
+  
+  Named args : tags           Comma separated list of tag sequences, String.
+               plate_number   Plate number (only relevant for Revio runs), Int.
+
+  Example    : $id = $self->generate_product_id($run, $well, tags => $tags);
   Description: Runs a python script which generates a product id from run,
                well and tag data.
 
 =cut
 
-sub generate_product_id {
-  my ($self, $run_name, $well_label, $tags, $plate_number) = @_;
+{
+  my $positional = 3;
+  my @named      = qw[tags plate_number];
 
-  my $command = join q[ ],
-    $ID_SCRIPT, '--run_name', $run_name, '--well_label', $well_label;
-  foreach my $tag (@{$tags}){
-    $command .= join q[ ], ' --tag', $tag;
-  }
-  if (defined $plate_number) { $command .= ' --plate_number '. $plate_number; }
-  $self->info("Generating product id: $command");
+  my $params     = function_params($positional, @named);
 
-  open my $id_product_script, q[-|], $command
-    or $self->logconfess('Cannot generate id_product ' . $CHILD_ERROR);
-  my $id_product = <$id_product_script>;
-  close $id_product_script
-    or $self->logconfess('Could not close id_product generation script');
-  $id_product =~ s/\s//xms;
-  if (length $id_product != $ID_LENGTH) {
-    $self->logcroak('Incorrect output length from id_product generation script, expected a 64 character string');
+  sub generate_product_id {
+    my ($self, $run_name, $well_label) = $params->parse(@_);
+
+    defined $run_name or
+      $self->logconfess('A defined run name argument is required');
+
+    defined $well_label or
+      $self->logconfess('A defined well label argument is required');
+
+    my $command = join q[ ],
+      $ID_SCRIPT, '--run_name', $run_name, '--well_label', $well_label;
+
+    if (defined $params->tags) {
+      foreach my $tag (@{$params->tags}){
+        $command .= join q[ ], ' --tag', $tag;
+      }
+    }
+    if (defined $params->plate_number) {
+      $command .= ' --plate_number '. $params->plate_number;
+    }
+    $self->info("Generating product id: $command");
+
+    open my $id_product_script, q[-|], $command
+      or $self->logconfess('Cannot generate id_product ' . $CHILD_ERROR);
+    my $id_product = <$id_product_script>;
+    close $id_product_script
+      or $self->logconfess('Could not close id_product generation script');
+    $id_product =~ s/\s//xms;
+    if (length $id_product != $ID_LENGTH) {
+      $self->logcroak('Incorrect output length from id_product generation script, expected a 64 character string');
+    }
+    return $id_product;
   }
-  return $id_product;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/WTSI/NPG/HTS/PacBio/Sequel/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Sequel/RunPublisher.pm
@@ -468,8 +468,7 @@ sub publish_sequence_files {
   my $id_product = $product->generate_product_id(
       $metadata->run_name,
       $self->remove_well_padding($metadata->run_name, $metadata->well_name),
-      undef,
-      $metadata->plate_number
+      plate_number => $metadata->plate_number
   );
 
   my @primary_avus   = $self->make_primary_metadata

--- a/lib/WTSI/NPG/HTS/PacBio/Sequel/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/Sequel/RunPublisher.pm
@@ -434,7 +434,8 @@ sub publish_sequence_files {
   # There will be 1 record for a non-multiplexed SMRT cell and >1
   # record for a multiplexed (currently no uuids recorded in XML).
   my @run_records =
-    $self->find_pacbio_runs($metadata->run_name, $metadata->well_name);
+    $self->find_pacbio_runs($metadata->run_name, $metadata->well_name,
+      undef, $metadata->plate_number);
 
   # R & D runs have no records in the ML warehouse
   my $is_r_and_d = @run_records ? 0 : 1;
@@ -465,8 +466,10 @@ sub publish_sequence_files {
   my $product = WTSI::NPG::HTS::PacBio::Sequel::Product->new();
 
   my $id_product = $product->generate_product_id(
-          $metadata->run_name,
-          $self->remove_well_padding($metadata->run_name, $metadata->well_name)
+      $metadata->run_name,
+      $self->remove_well_padding($metadata->run_name, $metadata->well_name),
+      undef,
+      $metadata->plate_number
   );
 
   my @primary_avus   = $self->make_primary_metadata

--- a/t/fixtures/ml_warehouse/300-PacBioRun.yml
+++ b/t/fixtures/ml_warehouse/300-PacBioRun.yml
@@ -2197,6 +2197,7 @@
   pac_bio_library_tube_legacy_id: '43509080'
   library_created_at: ~
   pac_bio_run_name: 'TRACTION-RUN-142'
+  plate_number: 1
 - id_pac_bio_tmp: '99057'
   last_updated: '2022-09-30 15:49:01'
   recorded_at: '2022-09-30 15:49:01'
@@ -2224,6 +2225,7 @@
   pac_bio_library_tube_legacy_id: ~
   library_created_at: ~
   pac_bio_run_name: 'TRACTION-RUN-282'
+  plate_number: 1 
 - id_pac_bio_tmp: '99058'
   last_updated: '2022-09-30 15:49:01'
   recorded_at: '2022-09-30 15:49:01'
@@ -2251,6 +2253,7 @@
   pac_bio_library_tube_legacy_id: ~
   library_created_at: ~
   pac_bio_run_name: 'TRACTION-RUN-282'
+  plate_number: 1
 - id_pac_bio_tmp: '99679'
   last_updated: '2022-11-04 14:28:27'
   recorded_at: '2022-11-04 14:28:27'
@@ -2278,6 +2281,7 @@
   pac_bio_library_tube_legacy_id: ~
   library_created_at: ~
   pac_bio_run_name: 'TRACTION-RUN-327'
+  plate_number: 1
 - id_pac_bio_tmp: '100461'
   last_updated: '2022-12-14 16:02:24'
   recorded_at: '2022-12-14 16:02:24'
@@ -2305,6 +2309,7 @@
   pac_bio_library_tube_legacy_id: ~
   library_created_at: ~
   pac_bio_run_name: 'TRACTION-RUN-387'
+  plate_number: 1
 - id_pac_bio_tmp: '103603'
   last_updated: '2023-04-04 15:17:03'
   recorded_at: '2023-04-04 15:17:03'
@@ -2332,6 +2337,7 @@
   pac_bio_library_tube_legacy_id: ~
   library_created_at: ~
   pac_bio_run_name: 'TRACTION-RUN-525'
+  plate_number: 1
 - id_pac_bio_tmp: '103604'
   last_updated: '2023-04-04 15:17:03'
   recorded_at: '2023-04-04 15:17:03'
@@ -2359,6 +2365,7 @@
   pac_bio_library_tube_legacy_id: ~
   library_created_at: ~
   pac_bio_run_name: 'TRACTION-RUN-525'
+  plate_number: 1
 - id_pac_bio_tmp: '103606'
   last_updated: '2022-12-14 16:02:24'
   recorded_at: '2022-12-14 16:02:24'
@@ -2386,3 +2393,4 @@
   pac_bio_library_tube_legacy_id: ~
   library_created_at: ~
   pac_bio_run_name: 'TRACTION-RUN-525'
+  plate_number: 1

--- a/t/lib/WTSI/NPG/HTS/PacBio/Sequel/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/PacBio/Sequel/RunPublisherTest.pm
@@ -870,9 +870,11 @@ sub check_primary_metadata {
     if ($obj->find_in_metadata($TARGET)){
       my @tag_meta = $obj->find_in_metadata($TAG_SEQUENCE);
       my @tags = map {$_->{value}} @tag_meta;
-      $expected_id = $product->generate_product_id($run_name, $well_label, \@tags, $pn);
+      $expected_id = $product->generate_product_id
+        ($run_name, $well_label, tags => \@tags, plate_number => $pn);
     }else{
-      $expected_id = $product->generate_product_id($run_name, $well_label, undef, $pn);
+      $expected_id = $product->generate_product_id
+        ($run_name, $well_label, plate_number => $pn);
     }
 
     is($product_id, $expected_id,


### PR DESCRIPTION
All previous PacBio runs have been from a single loading plate but the Revio can support multi (2) plate runs. This means the standard run, well, tag identifiers are no longer guaranteed to provide a unique identifier. Revio multi plate runs require plate number in addition to run, well, tag to identify correct meta data as well A01 could be on plate 1 and plate 2 on the same Revio run. This pull request is to extract plate number from Revio runs, use it where applicable to identify meta data & generate product hashes and add plate number as meta data in iRODS to relevant files. 