### PR TITLE
Update GHA: install iRODS clients outside of working directory

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,6 @@ jobs:
 
     env:
       SINGULARITY_VERSION: "3.11.1"
-      SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity-cache
       PERL_CACHE: ~/perl5 # Perlbrew and CPAN modules installed here, cached
       NPG_LIB: ~/perl5npg # NPG modules installed here, not cached
       WTSI_NPG_BUILD_BRANCH: ${{ github.base_ref || github.ref }}
@@ -56,6 +55,12 @@ jobs:
           --health-retries 6
 
     steps:
+      - name: "Set environmental variables based on other environmental variables"
+        run: |
+          echo "SINGULARITY_CACHEDIR=$HOME/.singularity-cache" >> $GITHUB_ENV
+          # '~' in SINGULARITY_CACHEDIR value (from say a env: section in this YAML) is not expanded by
+          # singularity so that paths used are misleading/unclear
+
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v3
@@ -93,22 +98,21 @@ jobs:
       - name: "Cache Singularity images"
         uses: actions/cache@v3
         with:
-          path: ${{ github.workspace }}/.singularity-cache
+          path: ${{ env.SINGULARITY_CACHEDIR }}
           key: ${{ runner.os }}-singularity
 
       - name: "Install iRODS client wrappers"
         env:
           DOCKER_IMAGE: ${{ matrix.client_image }}
-          PREFIX: ${{ github.workspace }}
         run: |
           # Use -s option for the wrappers to enable re-usable service instances
-          singularity exec docker://$DOCKER_IMAGE singularity-wrapper -s -p $PREFIX install
-          echo "$PREFIX/bin" >> $GITHUB_PATH
+          # Install is to HOME rather than workspace to avoid clashes with repo e.g. in bin/
+          singularity exec docker://$DOCKER_IMAGE singularity-wrapper -s -p $HOME/.local install
+          echo $HOME/.local/bin >> $GITHUB_PATH
 
       - name: "Configure iRODS clients"
         env:
           DOCKER_IMAGE: ${{ matrix.client_image }}
-          PREFIX: ${{ github.workspace }}
         run: |
           mkdir -p "$HOME/.irods"
           cat <<'EOF' > "$HOME/.irods/irods_environment.json"


### PR DESCRIPTION
in home directory

Avoid tests, which inspect scripts or Perl code in repo's own hierarchy, inspecting other tools which had previously been installed there by the GHA config by installing them in the home directory.