### PR TITLE
Unified logic for setting target and alt_target.

### DIFF
--- a/lib/WTSI/NPG/HTS/Illumina/Annotator.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/Annotator.pm
@@ -226,16 +226,10 @@ sub make_target_metadata {
     ($component->has_subset and $component->subset ne $YHUMAN)) {
     $target = 0;
   }
-  elsif ($alt_process) {
-    $target = 0;
-  }
 
-  my @avus = ($self->make_avu($TARGET, $target));
-  if ($alt_process) {
-    if (($component->has_subset and $component->subset ne 'phix') or
-      not $component->has_subset) {
-      push @avus, $self->make_avu($ALT_TARGET, 1);
-    }
+  my @avus = ($self->make_avu($TARGET, $alt_process ? 0 : $target));
+  if ($alt_process && $target) {
+    push @avus, $self->make_avu($ALT_TARGET, 1);
   }
 
   return @avus;

--- a/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/RunPublisherTest.pm
@@ -1407,20 +1407,21 @@ sub check_alt_process_metadata {
               [{attribute => $TARGET,
                 value     => 0}],
               "$file_name $TARGET metadata correct when alt_process");
-    if ($path =~ /phix/) {
+    is_deeply([$obj->get_avu($ALT_PROCESS)],
+              [{attribute => $ALT_PROCESS,
+                value     => $alt_process}],
+              "$file_name $ALT_PROCESS metadata correct when alt_process");
+
+    if (($path =~ /_phix/) || ($path =~ /\#0/)) {
       is_deeply([$obj->get_avu($ALT_TARGET)],
                 [undef],
-                "$file_name $ALT_TARGET metadata not set for phiX file");
-    }else{
+                "$file_name $ALT_TARGET metadata not set");
+    } else { # including _yhuman
       is_deeply([$obj->get_avu($ALT_TARGET)],
                 [{attribute => $ALT_TARGET,
                   value     => 1}],
                 "$file_name $ALT_TARGET metadata correct when alt_process");
     }
-     is_deeply([$obj->get_avu($ALT_PROCESS)],
-              [{attribute => $ALT_PROCESS,
-                value     => $alt_process}],
-              "$file_name $ALT_PROCESS metadata correct when alt_process");
   }
 }
 


### PR DESCRIPTION
alt_target iRODS metadata attribute value is now computed in the same way as the target metadata attribute value. To be consistent with prior practice, the alt_target value is assigned only when it is true.

This resolves the issue of tag zero files, which are  produced by the alternative process, having alt_target metadata attribute value of 1.