### PR TITLE
Feature: collect pipeline central, postqc and product release logs from BAM_basecalls folder

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -49,6 +49,7 @@ my $build = WTSI::DNAP::Utilities::Build->new
     'MooseX::Types'                 => '>= 0.45',
     'MooseX::Storage'               => 0,
     'MooseX::StrictConstructor'     => 0,
+    'Readonly'                      => 0,
     'Text::CSV'                     => '>= 1.33',
     'Try::Tiny'                     => '>= 0.12',
     'URI'                           => 0,

--- a/Build.PL
+++ b/Build.PL
@@ -21,6 +21,7 @@ my $build = WTSI::DNAP::Utilities::Build->new
    {
     'File::Copy::Recursive'         => 0,
     'File::Slurp'                   => 0,
+    'File::Spec'                    => 0,
     'File::Temp'                    => 0,
     'File::Which'                   => 0,
     'TAP::Harness'                  => '>= 3.30',

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -96,10 +96,15 @@ sub publish_logs {
   # find links
   my $find_llist = q[find . -type l];
 
+  # find pipeline central and post qc files right under the run folder directory
+  my $find_central_postqc =
+  	q[find . -maxdepth 1 -type f ] . 
+	q[\\( -name "*.log" -o -name "*.definitions.json" \\)];
+
   my $tarcmd = "tar cJf $tarpath --exclude-vcs --exclude='core*' -T -";
   my $cmd =
     qq[set -o pipefail && cd $search_root && ] .
-    qq[($find_dlist && $find_p4 && $find_llist) | $tarcmd];
+    qq[($find_dlist && $find_p4 && $find_llist && $find_central_postqc) | $tarcmd];
 
   try {
     WTSI::DNAP::Utilities::Runnable->new(executable => '/bin/bash',

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -175,7 +175,7 @@ Keith James E<lt>kdj@sanger.ac.ukE<gt>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2015, 2016 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2015, 2016, 2024 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -98,8 +98,8 @@ sub publish_logs {
 
   # find pipeline central and post qc files right under the run folder directory
   my $find_central_postqc =
-  	q[find . -maxdepth 1 -type f ] . 
-	q[\\( -name "*.log" -o -name "*.definitions.json" \\)];
+		q[find . -maxdepth 1 -type f ] .
+	  q[\\( -name "*.log" -o -name "*.definitions.json" \\)];
 
   my $tarcmd = "tar cJf $tarpath --exclude-vcs --exclude='core*' -T -";
   my $cmd =

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -103,7 +103,7 @@ sub publish_logs {
   my $analysis_logs_and_config =
     qq[find . -maxdepth $BAM_BASECALLS_DEPTH -type f ] .
     q[-a \\( -path "*/BAM_basecalls_*" -a -prune \\) ] .
-    q[-a \\( -name "*.log" -o -name "*.definitions.json" -o -name "*.yml" \\)];
+    q[-a \\( -name "*.log" -o -name "*.definitions.json" -o -name "product_release_*.yml" \\)];
 
   my $tarcmd = "tar cJf $tarpath --exclude-vcs --exclude='core*' -T -";
   my $cmd =

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -101,9 +101,9 @@ sub publish_logs {
 
   # find pipeline central and post qc files right under the run folder directory
   my $analysis_logs_and_config =
-		qq[find . -maxdepth $BAM_BASECALLS_DEPTH -type f ] .
-		q[-a \\( -path "*/BAM_basecalls_*" -a -prune \\) ] .
-		q[-a \\( -name "*.log" -o -name "*.definitions.json" -o -name "*.yml" \\)];
+    qq[find . -maxdepth $BAM_BASECALLS_DEPTH -type f ] .
+    q[-a \\( -path "*/BAM_basecalls_*" -a -prune \\) ] .
+    q[-a \\( -name "*.log" -o -name "*.definitions.json" -o -name "*.yml" \\)];
 
   my $tarcmd = "tar cJf $tarpath --exclude-vcs --exclude='core*' -T -";
   my $cmd =

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -100,7 +100,7 @@ sub publish_logs {
   my $find_llist = q[find . -type l];
 
   # find pipeline central and post qc files right under the run folder directory
-  my $find_central_postqc =
+  my $analysis_logs_and_config =
 		qq[find . -maxdepth $BAM_BASECALLS_DEPTH -type f ] .
 		q[-a \\( -path "*/BAM_basecalls_*" -a -prune \\) ] .
 		q[-a \\( -name "*.log" -o -name "*.definitions.json" \\)];
@@ -108,7 +108,7 @@ sub publish_logs {
   my $tarcmd = "tar cJf $tarpath --exclude-vcs --exclude='core*' -T -";
   my $cmd =
     qq[set -o pipefail && cd $search_root && ] .
-    qq[($find_dlist && $find_p4 && $find_llist && $find_central_postqc) | $tarcmd];
+    qq[($find_dlist && $find_p4 && $find_llist && $analysis_logs_and_config) | $tarcmd];
 
   try {
     WTSI::DNAP::Utilities::Runnable->new(executable => '/bin/bash',

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -24,8 +24,8 @@ with qw[
 our $VERSION = '';
 
 # Default
-our $DEFAULT_ROOT_COLL = '/seq';
-our $DEFAULT_LOG_COLL  = 'log';
+Readonly::Scalar my $DEFAULT_ROOT_COLL => '/seq';
+Readonly::Scalar my $DEFAULT_LOG_COLL => 'log';
 
 Readonly::Scalar my $BAM_BASECALLS_DEPTH => 4;
 

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -103,7 +103,7 @@ sub publish_logs {
   my $analysis_logs_and_config =
 		qq[find . -maxdepth $BAM_BASECALLS_DEPTH -type f ] .
 		q[-a \\( -path "*/BAM_basecalls_*" -a -prune \\) ] .
-		q[-a \\( -name "*.log" -o -name "*.definitions.json" \\)];
+		q[-a \\( -name "*.log" -o -name "*.definitions.json" -o -name "*.yml" \\)];
 
   my $tarcmd = "tar cJf $tarpath --exclude-vcs --exclude='core*' -T -";
   my $cmd =

--- a/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/LogPublisher.pm
@@ -7,6 +7,7 @@ use Moose;
 use MooseX::StrictConstructor;
 use POSIX qw[strftime];
 use Try::Tiny;
+use Readonly;
 
 use WTSI::NPG::HTS::DataObject;
 use WTSI::NPG::iRODS::Metadata qw[$ID_RUN];
@@ -25,6 +26,8 @@ our $VERSION = '';
 # Default
 our $DEFAULT_ROOT_COLL = '/seq';
 our $DEFAULT_LOG_COLL  = 'log';
+
+Readonly::Scalar my $BAM_BASECALLS_DEPTH => 4;
 
 has 'irods' =>
   (isa           => 'WTSI::NPG::iRODS',
@@ -98,8 +101,9 @@ sub publish_logs {
 
   # find pipeline central and post qc files right under the run folder directory
   my $find_central_postqc =
-		q[find . -maxdepth 1 -type f ] .
-	  q[\\( -name "*.log" -o -name "*.definitions.json" \\)];
+		qq[find . -maxdepth $BAM_BASECALLS_DEPTH -type f ] .
+		q[-a \\( -path "*/BAM_basecalls_*" -a -prune \\) ] .
+		q[-a \\( -name "*.log" -o -name "*.definitions.json" \\)];
 
   my $tarcmd = "tar cJf $tarpath --exclude-vcs --exclude='core*' -T -";
   my $cmd =

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -77,24 +77,24 @@ sub publish_logs : Test(12) {
 
 	# Test that the pipeline central, postqc and product release logs are archived together with the others
   Readonly::Scalar my $LOGS_COUNT => 43;
-	my @log_files =
-		('_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.definitions.json',
-		  '_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.definitions.json',
-		  '_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.log',
-		  '_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.log',
+  my @log_files =
+    ('_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.definitions.json',
+      '_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.definitions.json',
+      '_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.log',
+      '_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.log',
       'product_release_20241101-132705-1247165951.yml',
       'product_release_20241104-124525-1500421497.yml');
-	my $temp_dir = tempdir(CLEANUP => 1);
-	my $ref_name = '151211_HX3_18448_B_HHH55CCXX';
-	my $runfolder_path3 = File::Spec->catfile($temp_dir, $ref_name);
-	my $bam_basecall_folder3 = 
+  my $temp_dir = tempdir(CLEANUP => 1);
+  my $ref_name = '151211_HX3_18448_B_HHH55CCXX';
+  my $runfolder_path3 = File::Spec->catfile($temp_dir, $ref_name);
+  my $bam_basecall_folder3 = 
     File::Spec->catfile( $runfolder_path3, 'Data/Intensities/BAM_basecalls_20151214-085833');
-	dircopy("t/data/illumina/sequence/$ref_name", $runfolder_path3);
-	for my $log (@log_files) {
-		open my $handle, '>', File::Spec->catfile($bam_basecall_folder3, $log)
+  dircopy("t/data/illumina/sequence/$ref_name", $runfolder_path3);
+  for my $log (@log_files) {
+    open my $handle, '>', File::Spec->catfile($bam_basecall_folder3, $log)
       or die "error while creating test logs $log";
-		close $handle or die "error while closing test logs $log";
-	}
+    close $handle or die "error while closing test logs $log";
+  }
   my $pub3 = WTSI::NPG::HTS::Illumina::LogPublisher->new
     (irods           => $irods,
      runfolder_path  => $runfolder_path3,
@@ -105,12 +105,12 @@ sub publish_logs : Test(12) {
   ok($log_archive3, 'Log archive with pipeline central and post qc logs created');
 
   my $cmd_count_out = `iget $log_archive3 - | tar tJ | wc -l`;
-	ok(int($cmd_count_out) == $LOGS_COUNT, 'Correct number of files in the log archive');
+  ok(int($cmd_count_out) == $LOGS_COUNT, 'Correct number of files in the log archive');
 
-	my $cmd_list_out = `iget $log_archive3 - | tar tJ`;
-	for my $log (@log_files) {
-		ok(grep(/$log/, $cmd_list_out), "$log in archive file");
-	}
+  my $cmd_list_out = `iget $log_archive3 - | tar tJ`;
+  for my $log (@log_files) {
+    ok(grep(/$log/, $cmd_list_out), "$log in archive file");
+  }
 }
 
 1;

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -85,11 +85,11 @@ sub publish_logs : Test(12) {
       'product_release_20241101-132705-1247165951.yml',
       'product_release_20241104-124525-1500421497.yml');
   my $temp_dir = tempdir(CLEANUP => 1);
-  my $ref_name = '151211_HX3_18448_B_HHH55CCXX';
-  my $runfolder_path3 = File::Spec->catfile($temp_dir, $ref_name);
+  my $rf_name = '151211_HX3_18448_B_HHH55CCXX';
+  my $runfolder_path3 = File::Spec->catfile($temp_dir, $rf_name);
   my $bam_basecall_folder3 = 
     File::Spec->catfile( $runfolder_path3, 'Data/Intensities/BAM_basecalls_20151214-085833');
-  dircopy("t/data/illumina/sequence/$ref_name", $runfolder_path3);
+  dircopy("t/data/illumina/sequence/$rf_name", $runfolder_path3);
   for my $log (@log_files) {
     open my $handle, '>', File::Spec->catfile($bam_basecall_folder3, $log)
       or die "error while creating test logs $log";

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -40,7 +40,7 @@ sub teardown_test : Test(teardown) {
   $irods->remove_collection($irods_tmp_coll);
 }
 
-sub publish_logs : Test(10) {
+sub publish_logs : Test(12) {
   my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
                                     strict_baton_version => 0);
   my $runfolder_path1 = "$data_path/100818_IL32_10371";
@@ -75,20 +75,24 @@ sub publish_logs : Test(10) {
             {attribute => $ID_RUN,
              value     => 17550}, "Inferred $ID_RUN metadata is present");
 
-	# Test that the pipeline central and postqc logs are archived together with the others
-  Readonly::Scalar my $LOGS_COUNT => 41;
+	# Test that the pipeline central, postqc and product release logs are archived together with the others
+  Readonly::Scalar my $LOGS_COUNT => 43;
 	my @log_files =
 		('_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.definitions.json',
 		  '_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.definitions.json',
 		  '_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.log',
-		  '_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.log');
+		  '_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.log',
+      'product_release_20241101-132705-1247165951.yml',
+      'product_release_20241104-124525-1500421497.yml');
 	my $temp_dir = tempdir(CLEANUP => 1);
 	my $ref_name = '151211_HX3_18448_B_HHH55CCXX';
 	my $runfolder_path3 = File::Spec->catfile($temp_dir, $ref_name);
-	my $bam_basecall_folder3 = File::Spec->catfile( $runfolder_path3, 'Data/Intensities/BAM_basecalls_20151214-085833');
+	my $bam_basecall_folder3 = 
+    File::Spec->catfile( $runfolder_path3, 'Data/Intensities/BAM_basecalls_20151214-085833');
 	dircopy("t/data/illumina/sequence/$ref_name", $runfolder_path3);
 	for my $log (@log_files) {
-		open my $handle, '>', File::Spec->catfile($bam_basecall_folder3, $log) or die "error while creating test logs $log";
+		open my $handle, '>', File::Spec->catfile($bam_basecall_folder3, $log)
+      or die "error while creating test logs $log";
 		close $handle or die "error while closing test logs $log";
 	}
   my $pub3 = WTSI::NPG::HTS::Illumina::LogPublisher->new

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -76,19 +76,20 @@ sub publish_logs : Test(10) {
              value     => 17550}, "Inferred $ID_RUN metadata is present");
 
 	# Test that the pipeline central and postqc logs are archived together with the others
+  Readonly::Scalar my $LOGS_COUNT => 41;
 	my @log_files =
 		('_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.definitions.json',
-		'_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.definitions.json',
-		'_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.log',
-		'_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.log');
-	my $temp_dir = tempdir(CLEANUP => 0);
+		  '_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.definitions.json',
+		  '_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.log',
+		  '_software_npg_20241107_bin_npg_pipeline_post_qc_review_17550_20241104-124525-1544617117.log');
+	my $temp_dir = tempdir(CLEANUP => 1);
 	my $ref_name = '151211_HX3_18448_B_HHH55CCXX';
 	my $runfolder_path3 = File::Spec->catfile($temp_dir, $ref_name);
 	my $bam_basecall_folder3 = File::Spec->catfile( $runfolder_path3, 'Data/Intensities/BAM_basecalls_20151214-085833');
 	dircopy("t/data/illumina/sequence/$ref_name", $runfolder_path3);
 	for my $log (@log_files) {
-		open(my $handle, '>', File::Spec->catfile($bam_basecall_folder3, $log)) or die "error while creating test logs $log";
-		close($handle);
+		open my $handle, '>', File::Spec->catfile($bam_basecall_folder3, $log) or die "error while creating test logs $log";
+		close $handle or die "error while closing test logs $log";
 	}
   my $pub3 = WTSI::NPG::HTS::Illumina::LogPublisher->new
     (irods           => $irods,
@@ -99,13 +100,12 @@ sub publish_logs : Test(10) {
   my $log_archive3 = $pub3->publish_logs;
   ok($log_archive3, 'Log archive with pipeline central and post qc logs created');
 
-	my $cmd_count_out = `iget $log_archive3 - | tar tJ | wc -l`;
-	ok(int($cmd_count_out) == 41, 'Correct number of files in the log archive');
+  my $cmd_count_out = `iget $log_archive3 - | tar tJ | wc -l`;
+	ok(int($cmd_count_out) == $LOGS_COUNT, 'Correct number of files in the log archive');
 
 	my $cmd_list_out = `iget $log_archive3 - | tar tJ`;
-	my @file_list = split /\n\s\r/, $cmd_list_out;
 	for my $log (@log_files) {
-		ok($log =~ m/@file_list/, "$log in tar.xz file");
+		ok(grep(/$log/, $cmd_list_out), "$log in archive file");
 	}
 }
 

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -75,7 +75,7 @@ sub publish_logs : Test(12) {
             {attribute => $ID_RUN,
              value     => 17550}, "Inferred $ID_RUN metadata is present");
 
-	# Test that the pipeline central, postqc and product release logs are archived together with the others
+  # Test that the pipeline central, postqc and product release logs are archived together with the others
   Readonly::Scalar my $LOGS_COUNT => 43;
   my @log_files =
     ('_software_npg_20241107_bin_npg_pipeline_central_17550_20241101-132705-1566962201.definitions.json',

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -7,7 +7,7 @@ use Carp;
 use English qw[-no_match_vars];
 use Log::Log4perl;
 use Test::More;
-use File::Temp qw(tempdir tempfile);
+use File::Temp qw(tempdir);
 use File::Copy::Recursive qw(dircopy);
 use File::Spec;
 

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -10,6 +10,7 @@ use Test::More;
 use File::Temp qw(tempdir);
 use File::Copy::Recursive qw(dircopy);
 use File::Spec;
+use Readonly;
 
 use base qw[WTSI::NPG::HTS::Test];
 

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -98,7 +98,7 @@ sub publish_logs : Test(12) {
   my $pub3 = WTSI::NPG::HTS::Illumina::LogPublisher->new
     (irods           => $irods,
      runfolder_path  => $runfolder_path3,
-		 id_run          => 18448,
+     id_run          => 18448,
      dest_collection => "$irods_tmp_coll/publish_logs_pipecentral_qcpost");
 
   my $log_archive3 = $pub3->publish_logs;


### PR DESCRIPTION
`Central pipeline logs`, `post qc review JSON files` and `product release yml` files are under `BAM_basecalls` folder and contain the pipeline steps, commands and RoboQC config chosen. With this PR they will be archived in iRODS.