### PR TITLE
Fix: missing schema param in inferred id run test

### DIFF
--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -64,9 +64,10 @@ sub publish_logs : Test(12) {
   my $runfolder_path2 =
     "t/data/illumina/sequence/150910_HS40_17550_A_C75BCANXX";
   my $pub2 = WTSI::NPG::HTS::Illumina::LogPublisher->new
-    (irods           => $irods,
-     runfolder_path  => $runfolder_path2,
-     dest_collection => "$irods_tmp_coll/publish_logs_inferred_id_run");
+    (irods								=> $irods,
+     runfolder_path				=> $runfolder_path2,
+		 npg_tracking_schema	=> undef,
+     dest_collection			=> "$irods_tmp_coll/publish_logs_inferred_id_run");
 
   my $log_archive2 = $pub2->publish_logs;
   ok($log_archive2, 'Log archive created given a runfolder path');

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -63,6 +63,11 @@ sub publish_logs : Test(12) {
   # test the RunPublisher
   my $runfolder_path2 =
     "t/data/illumina/sequence/150910_HS40_17550_A_C75BCANXX";
+
+  # The tracking database handle must be specified, otherwise when
+  # the tracking schema file exists in .npg folder it tries to retrieve
+  # the db credentials from it and connect to the database defined there.
+  # By setting it to 'undef', the code avoids the database route.
   my $pub2 = WTSI::NPG::HTS::Illumina::LogPublisher->new
     (irods                => $irods,
      runfolder_path       => $runfolder_path2,

--- a/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
+++ b/t/lib/WTSI/NPG/HTS/Illumina/LogPublisherTest.pm
@@ -64,10 +64,10 @@ sub publish_logs : Test(12) {
   my $runfolder_path2 =
     "t/data/illumina/sequence/150910_HS40_17550_A_C75BCANXX";
   my $pub2 = WTSI::NPG::HTS::Illumina::LogPublisher->new
-    (irods								=> $irods,
-     runfolder_path				=> $runfolder_path2,
-		 npg_tracking_schema	=> undef,
-     dest_collection			=> "$irods_tmp_coll/publish_logs_inferred_id_run");
+    (irods                => $irods,
+     runfolder_path       => $runfolder_path2,
+     npg_tracking_schema  => undef,
+     dest_collection      => "$irods_tmp_coll/publish_logs_inferred_id_run");
 
   my $log_archive2 = $pub2->publish_logs;
   ok($log_archive2, 'Log archive created given a runfolder path');


### PR DESCRIPTION
During a `log_publisher` test, the connection to the tracking DB happens when the npg_tracking schema file is available on disk under the proper directory. If not present on disk the test passes skipping the connection. To avoid unexpected connections from this particular test when the file exists,`npg_tracking_schema` property should be set to `undef`.