### PR TITLE
Pacbio - in v13.1 onboard processing changes

### DIFF
--- a/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
@@ -643,7 +643,7 @@ sub publish_image_archive {
       elsif ($process_type eq $ONINST_REVIO1) {
         $file_types  = q{ccs_report.txt|fail_reads.lima_counts.txt|}.
           q{fail_reads.lima_summary.txt|hifi_reads.lima_counts.txt|}.
-          q{hifi_reads.lima_summary.txt|summary.json|fail_reads.json|hifi_reads.json|}.
+          q{hifi_reads.lima_summary.txt|summary.json|hifi_reads.json|}.
           q{ccs_report.json|fail_reads.unassigned.json|hifi_reads.unassigned.json};
       }
       elsif ($process_type eq $ONINST_REVIO2) {


### PR DESCRIPTION
Pacbio - in SMRT Link v13.1 onboard processing no longer produces a fail_reads.json file so remove this from the expected list of auxiliary files to be archived (in the qc tar archive) to iRODS.