### PR TITLE
Fix check for number of reads obtained via samtools

### DIFF
--- a/lib/WTSI/NPG/HTS/Illumina/AlnDataObject.pm
+++ b/lib/WTSI/NPG/HTS/Illumina/AlnDataObject.pm
@@ -282,7 +282,7 @@ sub _get_reads {
   if ($self->has_num_reads) {
     my $num_reads = $self->num_reads;
 
-    if (($num_read < $num_reads) && ($num_read <= $num_records)) {
+    if (($num_read < $num_reads) && ($num_reads <= $num_records)) {
       $self->logcroak("Only read $num_read reads from '$path' ",
                       'with samtools, when it is recorded ',
                       "as containing $num_reads reads");


### PR DESCRIPTION
This check is intended to ensure that when n reads are requested that n reads are obtained. The majority of BAM/CRAM files contain millions of reads, so in most cases simply checking for n reads is correct. In the cases where the file contains only fewer than n reads, the maximum we can expect is the number of reads in the file, rather than n.