### PR TITLE
Pacbio - add PbPathLister as a wrapper for WTSI::NPG::HTS::PathLister

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Unreleased
 
+ - Pacbio - add PbPathLister as a wrapper for WTSI::NPG::HTS::PathLister
+   to exclude dupicate 'pb_internal' files which appeared in off-instrument
+   runfolders in SMRT Link v25.4
+  
 Release 2.55.1 (2026-02-18)
  - Pacbio
    - tweak run deletion to skip runfolders restored only for SMRT Link GUI

--- a/MANIFEST
+++ b/MANIFEST
@@ -70,6 +70,7 @@ lib/WTSI/NPG/HTS/PacBio/MetaQuery.pm
 lib/WTSI/NPG/HTS/PacBio/MetaUpdater.pm
 lib/WTSI/NPG/HTS/PacBio/MetaXMLParser.pm
 lib/WTSI/NPG/HTS/PacBio/MonitorBase.pm
+lib/WTSI/NPG/HTS/PacBio/PbPathLister.pm
 lib/WTSI/NPG/HTS/PacBio/Product.pm
 lib/WTSI/NPG/HTS/PacBio/PublisherBase.pm
 lib/WTSI/NPG/HTS/PacBio/Reportdata.pm 

--- a/lib/WTSI/NPG/HTS/PacBio/AnalysisPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/AnalysisPublisher.pm
@@ -295,7 +295,7 @@ sub list_files {
   if (defined $subdironly && $subdironly == 1) {
     # for analysis files produced on the instrument we are only looking
     # in subdirectories for files to load directly to iRODS
-    my @allfiles = $self->list_directory
+    my @allfiles = $self->pb_list_directory
       ($self->runfolder_path, filter => $type, recurse => 1);
     foreach my $file (@allfiles) {
       my ($filename, $directory, $suffix) = fileparse($file);
@@ -305,10 +305,9 @@ sub list_files {
       }
     }
   } else {
-    @files = $self->list_directory
+    @files = $self->pb_list_directory
       ($self->runfolder_path, filter => $type, recurse => 1);
   }
-
   return \@files;
 }
 

--- a/lib/WTSI/NPG/HTS/PacBio/AnalysisPublisherBase.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/AnalysisPublisherBase.pm
@@ -76,22 +76,21 @@ sub _build_metadata_file{
   if (-d $output_path) {
     # As all analysis cell based all metafiles should have the correct run name,
     # well and plate number as no merged cell analysis - so just pick one.
-    my @files = $self->list_directory
+    my @files = $self->pb_list_directory
       ($output_path, filter => $METADATA_SET .q[.]. $METADATA_FORMAT . q[$]);
     push @metafiles, $files[0];
   } elsif ($self->is_oninstrument == 1 && $self->is_smtwelve == 1) {
     # Revio
-    @metafiles = $self->list_directory
+    @metafiles = $self->pb_list_directory
       ($self->analysis_path,
        filter => $self->movie_pattern .q[.]. $SMT_METADATA_SET .q[.]. $METADATA_FORMAT .q[$],
        recurse => 1)
   } elsif ($self->is_oninstrument == 1 ) {
     # Sequel IIe - as will never be upgraded from ICS v11
-    @metafiles = $self->list_directory
+    @metafiles = $self->pb_list_directory
       ($self->analysis_path,
        filter => $self->movie_pattern .q[.]. $METADATA_SET .q[.]. $METADATA_FORMAT .q[$])
   }
-
   if (@metafiles != 1) {
     $self->logcroak('Expect one xml file in '. $self->analysis_path);
   }

--- a/lib/WTSI/NPG/HTS/PacBio/AnalysisReport.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/AnalysisReport.pm
@@ -15,7 +15,7 @@ use WTSI::NPG::HTS::PacBio::Reportdata;
 
 with qw[
          WTSI::DNAP::Utilities::Loggable
-         WTSI::NPG::HTS::PathLister
+         WTSI::NPG::HTS::PacBio::PbPathLister
        ];
 
 our $VERSION = '';
@@ -94,7 +94,7 @@ sub generate_analysis_report {
 sub _read_deplex_files {
   my ($self) = @_;
 
-  my @files = $self->list_directory
+  my @files = $self->pb_list_directory
     ($self->runfolder_path, filter => $LIMA .q[$], recurse => 1);
 
   foreach my $file (@files) {
@@ -111,7 +111,7 @@ sub _read_ccs_files {
   my $spath = (-d catdir($self->analysis_path, $OUTPUT_DIR)) ?
     catdir($self->analysis_path, $OUTPUT_DIR) : $self->analysis_path;
 
-  my @files = $self->list_directory
+  my @files = $self->pb_list_directory
     ($spath, filter => $CCS_FILES .q[$], recurse => 1);
 
   if(@files >= 1){

--- a/lib/WTSI/NPG/HTS/PacBio/IsoSeqPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/IsoSeqPublisher.pm
@@ -93,11 +93,11 @@ sub publish_files {
     ($self->runfolder_path, $self->analysis_id .q[.]. $self->_metadata->movie_name .q[.]. $LOADED);
 
   if (! -f $lf ) {
-    my @all_files = $self->list_directory($self->runfolder_path);
+    my @all_files = $self->pb_list_directory($self->runfolder_path);
 
     ## remove files we don't want to publish and split list into sequence
     ## files and non sequence files
-    my @seq_files = $self->list_directory
+    my @seq_files = $self->pb_list_directory
       ($self->runfolder_path, filter => $FNAME_SEQUENCE . q[$]);
 
     my @not_excluded_files = grep { ! m{ $FNAME_EXCLUDED }smx } @all_files;
@@ -343,7 +343,7 @@ sub _get_primers {
   ## BioSample_1, BioSample_2...N (12 max) map to files 1 -> N
   ## except sample* files numbered 0 -> (N - 1) 
 
-  my @files = $self->list_directory($self->runfolder_path, filter => $PRIMERS_JSON);
+  my @files = $self->pb_list_directory($self->runfolder_path, filter => $PRIMERS_JSON);
 
   my (@names, @primers);
   if (scalar @files == 1) {

--- a/lib/WTSI/NPG/HTS/PacBio/PbPathLister.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/PbPathLister.pm
@@ -40,7 +40,7 @@ our $PATH_EXCLUDE = '^(?!.*pb_internal)';
        ($path, filter => $params->filter, recurse => $params->recurse);
 
      @files = grep { m{$PATH_EXCLUDE}msx } @files;
- 
+
      return @files;
    }
 

--- a/lib/WTSI/NPG/HTS/PacBio/PbPathLister.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/PbPathLister.pm
@@ -1,0 +1,81 @@
+package WTSI::NPG::HTS::PacBio::PbPathLister;
+
+use Moose::Role;
+
+use WTSI::DNAP::Utilities::Params qw[function_params];
+
+our $VERSION = '';
+
+with qw[
+         WTSI::DNAP::Utilities::Loggable
+         WTSI::NPG::HTS::PathLister
+       ];
+
+# Exclude all pacbio internal files
+our $PATH_EXCLUDE = '^(?!.*pb_internal)';
+
+=head2 pb_list_directory
+
+  Arg [1]      Directory path, Str.
+  Arg [2]      Item match regex, Str. Optional.
+
+  Example    : my @entries = $obj->pb_list_directory('/tmp', '^foo');
+  Description: Return entries in a directory, optionally filtered to match
+               match a regex. The regex is applied to the directory entry
+               with its leading path. Return entries with directories
+               sorted first.
+  Returntype : Array
+
+=cut
+
+{
+   my $positional = 2;
+   my @named      = qw[recurse filter];
+   my $params = function_params($positional, @named);
+
+   sub pb_list_directory {
+     my ($self, $path) = $params->parse(@_);
+
+     my @files = $self->list_directory
+       ($path, filter => $params->filter, recurse => $params->recurse);
+
+     @files = grep { m{$PATH_EXCLUDE}msx } @files;
+ 
+     return @files;
+   }
+
+}
+
+
+no Moose::Role;
+
+1;
+
+__END__
+
+=head1 NAME
+
+WTSI::NPG::HTS::PacBio::PbPathLister
+
+=head1 DESCRIPTION
+
+Always exclude duplicate files in certain named directories. These
+directories may be beta and not permanent.
+
+=head1 AUTHOR
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2026 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/lib/WTSI/NPG/HTS/PacBio/PublisherBase.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/PublisherBase.pm
@@ -20,10 +20,10 @@ use WTSI::NPG::iRODS;
 
 with qw[
          WTSI::DNAP::Utilities::Loggable
-         WTSI::NPG::HTS::PathLister
          WTSI::NPG::HTS::PacBio::Annotator
          WTSI::NPG::HTS::PacBio::MetaQuery
-       ];
+         WTSI::NPG::HTS::PacBio::PbPathLister
+         ];
 
 our $VERSION = '';
 

--- a/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
+++ b/lib/WTSI/NPG/HTS/PacBio/RunPublisher.pm
@@ -723,7 +723,7 @@ sub list_files {
   if ((defined $subdir && $subdir == 1) ||
       (defined $self->_is_onrevio && $self->_is_onrevio == 1)) {
     # only look in subdirectories for files to load
-    my @allfiles = $self->list_directory
+    my @allfiles = $self->pb_list_directory
       ($self->smrt_path($name), filter => $type, recurse => 1);
     foreach my $file (@allfiles) {
       my ($filename, $directory, $suffix) = fileparse($file);
@@ -733,7 +733,7 @@ sub list_files {
       }
     }
   } else {
-    @files = $self->list_directory($self->smrt_path($name), filter => $type);
+    @files = $self->pb_list_directory($self->smrt_path($name), filter => $type);
   }
 
   my $num_files = scalar @files;
@@ -765,8 +765,8 @@ sub smrt_names {
   my ($self) = @_;
 
   my $dir_pattern = $self->directory_pattern;
-  my @dirs = grep { -d } $self->list_directory($self->runfolder_path,
-                                               filter => $dir_pattern);
+  my @dirs = grep { -d } $self->pb_list_directory($self->runfolder_path,
+                                                  filter => $dir_pattern);
   my @names = sort map { first { $_ ne q[] } reverse splitdir($_) } @dirs;
 
   return @names;


### PR DESCRIPTION
Pacbio - add PbPathLister as a wrapper for WTSI::NPG::HTS::PathLister to exclude dupicate 'pb_internal' files which have appeared in off-instrument runfolders in SMRT Link v25.4
  
